### PR TITLE
kubernetes: Add test-runner configuration

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,0 +1,10 @@
+# Zephyr Infrastructure Kubernetes Configurations
+
+This directory contains the Kubernetes Infrastructure as Code (IaC)
+configuration files for the Zephyr infrastructure components.
+
+## Components
+
+* test-runner
+
+    * A sample auto-scaling GitHub Actions self-hosted runner for testing purposes.

--- a/kubernetes/test-runner/README.md
+++ b/kubernetes/test-runner/README.md
@@ -1,0 +1,31 @@
+# test-runner
+
+## Dependencies
+
+* cert-manager
+* actions-runner-controller
+
+## Deployment Procedure
+
+1. Deploy `cert-manager` component.
+
+    ```
+    kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.10.0/cert-manager.yaml
+    ```
+
+2. Deploy `actions-runner-controller` component.
+
+    ```
+    kubectl create -f https://github.com/actions-runner-controller/actions-runner-controller/releases/download/v0.25.2/actions-runner-controller.yaml
+    ```
+
+3. Create `controller-manager` secret.
+
+    ```
+    kubectl create secret generic controller-manager \
+      -n actions-runner-system \
+      --from-literal=github_app_id=${GITHUB_APP_ID} \
+      --from-literal=github_app_installation_id=${GITHUB_APP_INSTALL_ID} \
+      --from-file=github_app_private_key=${GITHUB_APP_PRIVATE_KEY_FILE_PATH}
+    ```
+

--- a/kubernetes/test-runner/test-runner.yaml
+++ b/kubernetes/test-runner/test-runner.yaml
@@ -1,0 +1,48 @@
+apiVersion: actions.summerwind.dev/v1alpha1
+kind: RunnerDeployment
+metadata:
+  name: test-runner-deployment
+spec:
+  template:
+    spec:
+      image: summerwind/actions-runner-dind
+      dockerdWithinRunnerContainer: true
+      organization: zephyrproject-rtos
+      labels:
+      - test-runner
+      containers:
+      - name: runner
+        resources:
+          limits:
+            cpu: "16.0"
+            memory: "32Gi"
+          requests:
+            cpu: "15.0"
+            memory: "24Gi"
+      nodeSelector:
+        InstanceType: spot
+      tolerations:
+      - key: "spotInstance"
+        operator: "Equal"
+        value: "true"
+        effect: "NoSchedule"
+---
+apiVersion: actions.summerwind.dev/v1alpha1
+kind: HorizontalRunnerAutoscaler
+metadata:
+  name: test-runner-deployment-autoscaler
+spec:
+  # Runners in the targeted RunnerDeployment won't be scaled down
+  # for 5 minutes instead of the default 10 minutes now
+  scaleDownDelaySecondsAfterScaleOut: 300
+  scaleTargetRef:
+    kind: RunnerDeployment
+    name: test-runner-deployment
+  minReplicas: 1
+  maxReplicas: 100
+  metrics:
+  - type: PercentageRunnersBusy
+    scaleUpThreshold: '0.75'
+    scaleDownThreshold: '0.3'
+    scaleUpAdjustment: 4
+    scaleDownAdjustment: 2


### PR DESCRIPTION
This commit adds `test-runner` sample GitHub Actions autoscaling self-hosted runner Kubernetes deployment configurations.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>