### PR TITLE
test-runner: Use private ECR image

### DIFF
--- a/kubernetes/test-runner/test-runner.yaml
+++ b/kubernetes/test-runner/test-runner.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   template:
     spec:
-      image: public.ecr.aws/e9a9g6w7/ci-zephyr-runner:latest
+      image: 724087766192.dkr.ecr.us-east-2.amazonaws.com/ci-zephyr-runner:latest
       dockerdWithinRunnerContainer: true
       organization: zephyrproject-rtos
       labels:


### PR DESCRIPTION
This commit updates the test-runner to use an image from the private ECR repository so that any ECR image pull traffic can be routed internally through a VPC endpoint without going through the NAT gateway.

Note that AWS does not allow creating a VPC endpoint for the public ECR repositories.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>