### PR TITLE
test-runner: Run Docker daemon in a sidecar container

### DIFF
--- a/kubernetes/test-runner/test-runner.yaml
+++ b/kubernetes/test-runner/test-runner.yaml
@@ -5,20 +5,28 @@ metadata:
 spec:
   template:
     spec:
-      image: 724087766192.dkr.ecr.us-east-2.amazonaws.com/ci-zephyr-runner:latest
-      dockerdWithinRunnerContainer: true
       organization: zephyrproject-rtos
       labels:
       - test-runner
       containers:
       - name: runner
+        image: 724087766192.dkr.ecr.us-east-2.amazonaws.com/ci-zephyr-runner-arc-runner:latest
         resources:
           limits:
             cpu: "16.0"
             memory: "32Gi"
           requests:
-            cpu: "15.0"
-            memory: "24Gi"
+            cpu: "7.5"
+            memory: "12Gi"
+      - name: docker
+        image: 724087766192.dkr.ecr.us-east-2.amazonaws.com/ci-zephyr-runner-arc-dind:latest
+        resources:
+          limits:
+            cpu: "16.0"
+            memory: "32Gi"
+          requests:
+            cpu: "7.5"
+            memory: "12Gi"
       nodeSelector:
         InstanceType: spot
       tolerations:


### PR DESCRIPTION
This commit updates the test-runner configurations to run the Docker daemon (dockerd) in a separate sidecar container (`docker` container), instead of using runner+dind container.

This ensures that the privileged Docker-in-Docker Docker daemon container is isolated from the GitHub Actions runner container.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>