### PR TITLE
zephyr-alpha: Enable EBS and EFS CSI drivers

### DIFF
--- a/terraform/zephyr-alpha/main.tf
+++ b/terraform/zephyr-alpha/main.tf
@@ -267,8 +267,11 @@ module "eks_blueprints_kubernetes_addons" {
   eks_oidc_provider    = module.eks_blueprints.oidc_provider
   eks_cluster_version  = module.eks_blueprints.eks_cluster_version
 
-  enable_metrics_server     = true
-  enable_cluster_autoscaler = true
+  enable_amazon_eks_aws_ebs_csi_driver = true
+  enable_aws_efs_csi_driver            = true
+  enable_metrics_server                = true
+  enable_cluster_autoscaler            = true
+
   cluster_autoscaler_helm_config = {
     set = [
       {


### PR DESCRIPTION
This commit enables the AWS EBS and EFS storage CSI drivers to facilitate mounting EBS volumes and EFS filesystems inside the Kubernetes pods.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>