### PR TITLE
zephyr-alpha: Add EFS storage class

### DIFF
--- a/terraform/zephyr-alpha/main.tf
+++ b/terraform/zephyr-alpha/main.tf
@@ -390,6 +390,24 @@ resource "aws_security_group" "efs" {
   tags = local.tags
 }
 
+resource "kubernetes_storage_class" "efs_sc" {
+  metadata {
+    name = "efs"
+  }
+
+  storage_provisioner = "ebs.csi.aws.com"
+  reclaim_policy      = "Delete"
+
+  parameters = {
+    provisioningMode = "efs-ap"
+    fileSystemId     = aws_efs_file_system.efs.id
+    directoryPerms   = "700"
+    gidRangeStart    = "1000"
+    gidRangeEnd      = "2000"
+    basePath         = "/dynamic"
+  }
+}
+
 #---------------------------------------------------------------
 # Custom IAM roles for Node Groups
 #---------------------------------------------------------------


### PR DESCRIPTION
This commit adds a Kubernetes storage class for the Elastic File System (EFS) so that persistent volumes can be dynamically provisioned onto the cluster main EFS filesystem.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>