### PR TITLE
zephyr-alpha: Fix EFS storage class provider

### DIFF
--- a/terraform/zephyr-alpha/main.tf
+++ b/terraform/zephyr-alpha/main.tf
@@ -395,7 +395,7 @@ resource "kubernetes_storage_class" "efs_sc" {
     name = "efs"
   }
 
-  storage_provisioner = "ebs.csi.aws.com"
+  storage_provisioner = "efs.csi.aws.com"
   reclaim_policy      = "Delete"
 
   parameters = {


### PR DESCRIPTION
The EFS storage provider is `efs.csi.aws.com`.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>