### PR TITLE
zephyr-alpha: Set EFS storage class uid and gid to 1000

### DIFF
--- a/terraform/zephyr-alpha/main.tf
+++ b/terraform/zephyr-alpha/main.tf
@@ -402,8 +402,8 @@ resource "kubernetes_storage_class" "efs_sc" {
     provisioningMode = "efs-ap"
     fileSystemId     = aws_efs_file_system.efs.id
     directoryPerms   = "700"
-    gidRangeStart    = "1000"
-    gidRangeEnd      = "2000"
+    uid              = "1000"
+    gid              = "1000"
     basePath         = "/dynamic"
   }
 }


### PR DESCRIPTION
This commit updates the EFS storage class definition to set the uid and gid for accessing the EFS filesystem to 1000.

This ensures that the EFS volumes and its contents are assigned the uid and gid of 1000, which is often the id for the default non-root user, and not assigned an arbitrary gid.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>