### PR TITLE
zephyr-alpha: Delete EFS access point root directory

### DIFF
--- a/terraform/zephyr-alpha/main.tf
+++ b/terraform/zephyr-alpha/main.tf
@@ -272,6 +272,15 @@ module "eks_blueprints_kubernetes_addons" {
   enable_metrics_server                = true
   enable_cluster_autoscaler            = true
 
+  aws_efs_csi_driver_helm_config = {
+    set = [
+      {
+        name = "controller.deleteAccessPointRootDir"
+        value = "true"
+      }
+    ]
+  }
+
   cluster_autoscaler_helm_config = {
     set = [
       {


### PR DESCRIPTION
This commit updates the EFS CSI driver configurations to delete the access point root directory when an access point is deleted.

This ensures that the contents of a persistent volume is deleted when a persistent volume claim is deleted (i.e. a dynamically provisioned EFS volume is deleted).

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>