### PR TITLE
zephyr-alpha: Enable nginx ingress controller

### DIFF
--- a/terraform/zephyr-alpha/main.tf
+++ b/terraform/zephyr-alpha/main.tf
@@ -271,6 +271,8 @@ module "eks_blueprints_kubernetes_addons" {
   enable_cluster_autoscaler            = true
   enable_amazon_eks_coredns            = true
   enable_amazon_eks_kube_proxy         = true
+  enable_aws_load_balancer_controller  = true
+  enable_ingress_nginx                 = true
   enable_amazon_eks_aws_ebs_csi_driver = true
   enable_aws_efs_csi_driver            = true
 
@@ -292,6 +294,11 @@ module "eks_blueprints_kubernetes_addons" {
                 EOT
       }
     ]
+  }
+
+  ingress_nginx_helm_config = {
+    version = "4.0.17"
+    values  = [templatefile("${path.module}/nginx-values.yaml", {})]
   }
 
   aws_efs_csi_driver_helm_config = {

--- a/terraform/zephyr-alpha/nginx-values.yaml
+++ b/terraform/zephyr-alpha/nginx-values.yaml
@@ -1,0 +1,11 @@
+controller:
+  service:
+    externalTrafficPolicy: "Local"
+    annotations:
+      # AWS Load Balancer Controller Annotations
+      service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
+      service.beta.kubernetes.io/aws-load-balancer-attributes: load_balancing.cross_zone.enabled=true
+      service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: '60'
+      service.beta.kubernetes.io/aws-load-balancer-type: 'external'
+      service.beta.kubernetes.io/aws-load-balancer-scheme: 'internet-facing'
+      service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: 'ip'


### PR DESCRIPTION
This commit updates the Kubernetes cluster configurations to enable
nginx as an ingress controller with AWS Load Balancer Controller
integration.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>