### PR TITLE
zephyr-alpha: Allow access from stephanosio

### DIFF
--- a/terraform/zephyr-alpha/main.tf
+++ b/terraform/zephyr-alpha/main.tf
@@ -63,6 +63,11 @@ module "eks_blueprints" {
       userarn  = "arn:aws:iam::724087766192:user/terraform-cloud"
       username = "terraform-cloud"
       groups   = ["system:masters"]
+    },
+    {
+      userarn  = "arn:aws:iam::724087766192:user/stephanosio"
+      username = "stephanosio"
+      groups   = ["system:masters"]
     }
   ]
 


### PR DESCRIPTION
This commit updates the Kubernetes cluster configurations to allow the 'stephanosio' IAM user to access the cluster resources as an administrator.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>