### PR TITLE
zephyr-alpha: Create authentication secret

### DIFF
--- a/terraform/zephyr-alpha/main.tf
+++ b/terraform/zephyr-alpha/main.tf
@@ -325,6 +325,10 @@ module "eks_blueprints_kubernetes_addons" {
     version = "0.21.1"
     set = [
       {
+        name  = "authSecret.create"
+        value = "true"
+      },
+      {
         name  = "authSecret.github_app_id"
         value = var.actions_runner_controller_github_app_id
       },


### PR DESCRIPTION
This commit updates the Actions Runner Controller configurations to create the runner controller app authentication secret.

Without this, the controller pod fails to properly initialise.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>