### PR TITLE
test-runner: Add webhook scale-up trigger

### DIFF
--- a/kubernetes/test-runner/test-runner.yaml
+++ b/kubernetes/test-runner/test-runner.yaml
@@ -60,10 +60,10 @@ spec:
   # Runners in the targeted RunnerDeployment won't be scaled down
   # for 5 minutes instead of the default 10 minutes now
   scaleDownDelaySecondsAfterScaleOut: 300
-  scaleUpTriggers:
-  - githubEvent:
-      workflowJob: {}
-    duration: "15m"
+  # scaleUpTriggers:
+  # - githubEvent:
+  #     workflowJob: {}
+  #   duration: "15m"
   metrics:
   - type: PercentageRunnersBusy
     scaleUpThreshold: '0.75'


### PR DESCRIPTION
This commit adds a GitHub workflow job webhook scale-up trigger for the
test runner horizontal runner autoscaler, which allows the autoscaler
to adjust the pod scaling based on the queued and completed jobs
reported by GitHub through the webhook.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>