### PR TITLE
test-runner: Adjust autoscaler configurations for improved stability

### DIFF
--- a/kubernetes/test-runner/test-runner.yaml
+++ b/kubernetes/test-runner/test-runner.yaml
@@ -57,16 +57,14 @@ spec:
     name: test-runner-deployment
   minReplicas: 1
   maxReplicas: 100
-  # Runners in the targeted RunnerDeployment won't be scaled down
-  # for 5 minutes instead of the default 10 minutes now
-  scaleDownDelaySecondsAfterScaleOut: 300
+  scaleDownDelaySecondsAfterScaleOut: 600
   # scaleUpTriggers:
   # - githubEvent:
   #     workflowJob: {}
   #   duration: "15m"
   metrics:
   - type: PercentageRunnersBusy
-    scaleUpThreshold: '0.75'
-    scaleDownThreshold: '0.3'
+    scaleUpThreshold: '1.0'
+    scaleDownThreshold: '0.9'
     scaleUpAdjustment: 10
     scaleDownAdjustment: 5


### PR DESCRIPTION
This commit adjusts the test runner autoscaler configurations to improve the overall stability of the autoscaler.

* The scale-up threshold has been adjusted to 1.0 to ensure that the scale-up occurs only when all the available runners are busy. This prevents the autoscaler from overallocating the runners.

* The scale-down threshold has been adjusted to 0.9 to ensure that the scale-down occurs even when a small number of runners are idling. This prevents the autoscaler from leaving too many runners idling.

* The scale-down delay afer scale-out has been adjusted to 10 minutes (600 seconds) to ensure that the autoscaler does not attempt to scale down while the new jobs are being assigned to the scaled-up runners.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>