### PR TITLE
zephyr-alpha: Enable ARC webhook server secret

### DIFF
--- a/terraform/zephyr-alpha/main.tf
+++ b/terraform/zephyr-alpha/main.tf
@@ -347,12 +347,24 @@ module "eks_blueprints_kubernetes_addons" {
       {
         name  = "githubWebhookServer.enabled"
         value = "true"
+      },
+      {
+        name  = "githubWebhookServer.secret.enabled"
+        value = "true"
+      },
+      {
+        name  = "githubWebhookServer.secret.create"
+        value = "true"
       }
     ]
     set_sensitive = [
       {
         name  = "authSecret.github_app_private_key"
         value = var.actions_runner_controller_github_app_private_key
+      },
+      {
+        name  = "githubWebhookServer.secret.github_webhook_secret_token"
+        value = var.actions_runner_controller_webhook_server_secret
       }
     ]
   }

--- a/terraform/zephyr-alpha/variables.tf
+++ b/terraform/zephyr-alpha/variables.tf
@@ -28,3 +28,10 @@ variable "actions_runner_controller_webhook_server_host" {
   type        = string
   default     = "webhook.arc-alpha.ci.zephyrproject.io"
 }
+
+variable "actions_runner_controller_webhook_server_secret" {
+  description = "Webhook server secret for Actions Runner Controller"
+  type        = string
+  sensitive   = true
+  default     = "testwebhookserversecret1234"
+}


### PR DESCRIPTION
This commit enables the Actions Runner Controller webhook server secret to ensure that only authorised clients (from GitHub) can deliver the webhooks.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>