### PR TITLE
zephyr-alpha: Deploy Kube Prometheus Stack

### DIFF
--- a/terraform/zephyr-alpha/main.tf
+++ b/terraform/zephyr-alpha/main.tf
@@ -292,6 +292,7 @@ module "eks_blueprints_kubernetes_addons" {
   enable_amazon_eks_aws_ebs_csi_driver = true
   enable_aws_efs_csi_driver            = true
   enable_kubernetes_dashboard          = true
+  enable_kube_prometheus_stack         = true
   enable_actions_runner_controller     = true
 
   # Cluster Autoscaler Configurations
@@ -345,6 +346,16 @@ module "eks_blueprints_kubernetes_addons" {
       {
         name = "controller.deleteAccessPointRootDir"
         value = "true"
+      }
+    ]
+  }
+
+  # Kube Prometheus Stack Configurations
+  kube_prometheus_stack_helm_config = {
+    set_sensitive = [
+      {
+        name  = "grafana.adminPassword"
+        value = var.kube_prometheus_stack_grafana_password
       }
     ]
   }

--- a/terraform/zephyr-alpha/variables.tf
+++ b/terraform/zephyr-alpha/variables.tf
@@ -10,6 +10,13 @@ variable "github_organization" {
   default     = "zephyrproject-rtos"
 }
 
+variable "kube_prometheus_stack_grafana_password" {
+  description = "Grafana password for Kube Prometheus Stack"
+  type        = string
+  sensitive   = true
+  default     = "grafana"
+}
+
 variable "actions_runner_controller_github_app_id" {
   description = "GitHub app ID for Actions Runner Controller"
   type        = string


### PR DESCRIPTION
This commit updates the Kubernetes configurations to deploy the Kube Prometheus Stack, which includes Prometheus for data collection and Grafana for data visualisation.

The Grafana instance can be accessed via port-forwarding:

  kubectl -n kube-prometheus-stack port-forward \
          service/kube-prometheus-stack-grafana 3000:http-web

  http://localhost:3000/

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>