### PR TITLE
zephyr-aws-blueprints: Do not load config file for kubectl

### DIFF
--- a/terraform/zephyr-aws-blueprints/main.tf
+++ b/terraform/zephyr-aws-blueprints/main.tf
@@ -12,6 +12,7 @@ provider "kubectl" {
   host                   = module.eks_blueprints.eks_cluster_endpoint
   cluster_ca_certificate = base64decode(module.eks_blueprints.eks_cluster_certificate_authority_data)
   token                  = data.aws_eks_cluster_auth.this.token
+  load_config_file       = false
 }
 
 provider "helm" {


### PR DESCRIPTION
Loading kubectl config file leads to an "apply" failure on the Terraform cloud.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>