### PR TITLE
terraform: Remove obsolete repository cache configuration variable

### DIFF
--- a/terraform/zephyr-alpha/main.tf
+++ b/terraform/zephyr-alpha/main.tf
@@ -40,8 +40,6 @@ module "zephyr_aws_blueprints" {
   actions_runner_controller_webhook_server_host   = "webhook.arc-alpha.ci.zephyrproject.io"
   actions_runner_controller_webhook_server_secret = var.actions_runner_controller_webhook_server_secret
 
-  enable_zephyr_runner_repo_cache = true
-
   enable_zephyr_runner_linux_x64_xlarge = true
   enable_zephyr_runner_linux_x64_4xlarge = true
 }

--- a/terraform/zephyr-aws-blueprints/variables.tf
+++ b/terraform/zephyr-aws-blueprints/variables.tf
@@ -114,12 +114,6 @@ variable "actions_runner_controller_webhook_server_secret" {
   sensitive   = true
 }
 
-variable "enable_zephyr_runner_repo_cache" {
-  description = "Enable Zephyr Runner repository cache"
-  type        = bool
-  default     = false
-}
-
 variable "enable_zephyr_runner_linux_x64_xlarge" {
   description = "Enable Zephyr Runner linux-x64-xlarge"
   type        = bool

--- a/terraform/zephyr-beta/main.tf
+++ b/terraform/zephyr-beta/main.tf
@@ -40,8 +40,6 @@ module "zephyr_aws_blueprints" {
   actions_runner_controller_webhook_server_host   = "webhook.arc-beta.ci.zephyrproject.io"
   actions_runner_controller_webhook_server_secret = var.actions_runner_controller_webhook_server_secret
 
-  enable_zephyr_runner_repo_cache = false
-
   enable_zephyr_runner_linux_x64_xlarge = false
   enable_zephyr_runner_linux_x64_4xlarge = false
 }


### PR DESCRIPTION
This commit removes the Terraform configuration variable for the now- obsolete EFS-based repository cache.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>