### PR TITLE
zephyr-runner: Filter by node size label

### DIFF
--- a/kubernetes/zephyr-runner/zephyr-runner-linux-x64-4xlarge.yaml
+++ b/kubernetes/zephyr-runner/zephyr-runner-linux-x64-4xlarge.yaml
@@ -39,7 +39,8 @@ spec:
         hostPath:
           path: /var/lib/docker-dind/overlay2
       nodeSelector:
-        InstanceType: spot
+        instanceType: spot
+        instanceSize: 4xlarge
       tolerations:
       - key: "spotInstance"
         operator: "Equal"

--- a/kubernetes/zephyr-runner/zephyr-runner-linux-x64-xlarge.yaml
+++ b/kubernetes/zephyr-runner/zephyr-runner-linux-x64-xlarge.yaml
@@ -39,7 +39,8 @@ spec:
         hostPath:
           path: /var/lib/docker-dind/overlay2
       nodeSelector:
-        InstanceType: spot
+        instanceType: spot
+        instanceSize: xlarge
       tolerations:
       - key: "spotInstance"
         operator: "Equal"


### PR DESCRIPTION
This commit updates the zephyr-runner Kubernetes manifests to filter the nodes that the pods run on by the node size label (`instanceSize`).

This ensures that, for instance, the `zephyr-runner-linux-x64-xlarge` runner pods do not get scheduled onto the nodes in the 4xlarge node group.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>