### PR TITLE
Add ARM64 runners

### DIFF
--- a/kubernetes/test-runner/test-runner-linux-arm64-4xlarge.yaml
+++ b/kubernetes/test-runner/test-runner-linux-arm64-4xlarge.yaml
@@ -1,0 +1,65 @@
+apiVersion: actions.summerwind.dev/v1alpha1
+kind: RunnerDeployment
+metadata:
+  name: test-runner-linux-arm64-4xlarge-deployment
+  namespace: zephyr-runner
+spec:
+  template:
+    spec:
+      organization: zephyrproject-rtos
+      labels:
+      - test-runner-linux-arm64-4xlarge
+      dockerdWithinRunnerContainer: true
+      image: 724087766192.dkr.ecr.us-east-2.amazonaws.com/ci-zephyr-runner-arc:latest
+      resources:
+        limits:
+          cpu: "16.0"
+          memory: "32Gi"
+        requests:
+          cpu: "15.0"
+          memory: "24Gi"
+      volumeMounts:
+      - mountPath: "/repo-cache"
+        name: repo-cache
+        readOnly: true
+      - mountPath: "/var/lib/docker/image"
+        name: docker-image
+      - mountPath: "/var/lib/docker/overlay2"
+        name: docker-overlay2
+      volumes:
+      - name: repo-cache
+        hostPath:
+          path: /pod-cache/repos
+      - name: docker-image
+        hostPath:
+          path: /var/lib/docker-dind/image
+      - name: docker-overlay2
+        hostPath:
+          path: /var/lib/docker-dind/overlay2
+      nodeSelector:
+        instanceType: spot
+        instanceSize: 4xlarge
+        instanceArch: arm64
+        instanceOs: linux
+      tolerations:
+      - key: "spotInstance"
+        operator: "Equal"
+        value: "true"
+        effect: "NoSchedule"
+---
+apiVersion: actions.summerwind.dev/v1alpha1
+kind: HorizontalRunnerAutoscaler
+metadata:
+  name: test-runner-linux-arm64-4xlarge-deployment-autoscaler
+  namespace: zephyr-runner
+spec:
+  scaleTargetRef:
+    kind: RunnerDeployment
+    name: test-runner-linux-arm64-4xlarge-deployment
+  minReplicas: 0
+  maxReplicas: 100
+  scaleDownDelaySecondsAfterScaleOut: 60
+  metrics:
+  - type: TotalNumberOfQueuedAndInProgressWorkflowRuns
+    repositoryNames:
+    - zephyr-testing

--- a/kubernetes/test-runner/test-runner-linux-arm64-4xlarge.yaml
+++ b/kubernetes/test-runner/test-runner-linux-arm64-4xlarge.yaml
@@ -63,3 +63,4 @@ spec:
   - type: TotalNumberOfQueuedAndInProgressWorkflowRuns
     repositoryNames:
     - zephyr-testing
+    - sdk-ng-testing

--- a/kubernetes/test-runner/test-runner-linux-arm64-xlarge.yaml
+++ b/kubernetes/test-runner/test-runner-linux-arm64-xlarge.yaml
@@ -63,3 +63,4 @@ spec:
   - type: TotalNumberOfQueuedAndInProgressWorkflowRuns
     repositoryNames:
     - zephyr-testing
+    - sdk-ng-testing

--- a/kubernetes/test-runner/test-runner-linux-arm64-xlarge.yaml
+++ b/kubernetes/test-runner/test-runner-linux-arm64-xlarge.yaml
@@ -1,0 +1,65 @@
+apiVersion: actions.summerwind.dev/v1alpha1
+kind: RunnerDeployment
+metadata:
+  name: test-runner-linux-arm64-xlarge-deployment
+  namespace: zephyr-runner
+spec:
+  template:
+    spec:
+      organization: zephyrproject-rtos
+      labels:
+      - test-runner-linux-arm64-xlarge
+      dockerdWithinRunnerContainer: true
+      image: 724087766192.dkr.ecr.us-east-2.amazonaws.com/ci-zephyr-runner-arc:latest
+      resources:
+        limits:
+          cpu: "4.0"
+          memory: "8Gi"
+        requests:
+          cpu: "3.5"
+          memory: "5Gi"
+      volumeMounts:
+      - mountPath: "/repo-cache"
+        name: repo-cache
+        readOnly: true
+      - mountPath: "/var/lib/docker/image"
+        name: docker-image
+      - mountPath: "/var/lib/docker/overlay2"
+        name: docker-overlay2
+      volumes:
+      - name: repo-cache
+        hostPath:
+          path: /pod-cache/repos
+      - name: docker-image
+        hostPath:
+          path: /var/lib/docker-dind/image
+      - name: docker-overlay2
+        hostPath:
+          path: /var/lib/docker-dind/overlay2
+      nodeSelector:
+        instanceType: spot
+        instanceSize: xlarge
+        instanceArch: arm64
+        instanceOs: linux
+      tolerations:
+      - key: "spotInstance"
+        operator: "Equal"
+        value: "true"
+        effect: "NoSchedule"
+---
+apiVersion: actions.summerwind.dev/v1alpha1
+kind: HorizontalRunnerAutoscaler
+metadata:
+  name: test-runner-linux-arm64-xlarge-deployment-autoscaler
+  namespace: zephyr-runner
+spec:
+  scaleTargetRef:
+    kind: RunnerDeployment
+    name: test-runner-linux-arm64-xlarge-deployment
+  minReplicas: 0
+  maxReplicas: 100
+  scaleDownDelaySecondsAfterScaleOut: 60
+  metrics:
+  - type: TotalNumberOfQueuedAndInProgressWorkflowRuns
+    repositoryNames:
+    - zephyr-testing

--- a/kubernetes/test-runner/test-runner-linux-x64-4xlarge.yaml
+++ b/kubernetes/test-runner/test-runner-linux-x64-4xlarge.yaml
@@ -1,14 +1,14 @@
 apiVersion: actions.summerwind.dev/v1alpha1
 kind: RunnerDeployment
 metadata:
-  name: test-runner-deployment
+  name: test-runner-linux-x64-4xlarge-deployment
   namespace: zephyr-runner
 spec:
   template:
     spec:
       organization: zephyrproject-rtos
       labels:
-      - test-runner
+      - test-runner-linux-x64-4xlarge
       dockerdWithinRunnerContainer: true
       image: 724087766192.dkr.ecr.us-east-2.amazonaws.com/ci-zephyr-runner-arc:latest
       resources:
@@ -50,12 +50,12 @@ spec:
 apiVersion: actions.summerwind.dev/v1alpha1
 kind: HorizontalRunnerAutoscaler
 metadata:
-  name: test-runner-deployment-autoscaler
+  name: test-runner-linux-x64-4xlarge-deployment-autoscaler
   namespace: zephyr-runner
 spec:
   scaleTargetRef:
     kind: RunnerDeployment
-    name: test-runner-deployment
+    name: test-runner-linux-x64-4xlarge-deployment
   minReplicas: 0
   maxReplicas: 100
   scaleDownDelaySecondsAfterScaleOut: 60

--- a/kubernetes/test-runner/test-runner-linux-x64-4xlarge.yaml
+++ b/kubernetes/test-runner/test-runner-linux-x64-4xlarge.yaml
@@ -67,6 +67,7 @@ spec:
   - type: TotalNumberOfQueuedAndInProgressWorkflowRuns
     repositoryNames:
     - zephyr-testing
+    - sdk-ng-testing
   # metrics:
   # - type: PercentageRunnersBusy
   #   scaleUpThreshold: '1.0'

--- a/kubernetes/test-runner/test-runner-linux-x64-xlarge.yaml
+++ b/kubernetes/test-runner/test-runner-linux-x64-xlarge.yaml
@@ -1,0 +1,65 @@
+apiVersion: actions.summerwind.dev/v1alpha1
+kind: RunnerDeployment
+metadata:
+  name: test-runner-linux-x64-xlarge-deployment
+  namespace: zephyr-runner
+spec:
+  template:
+    spec:
+      organization: zephyrproject-rtos
+      labels:
+      - test-runner-linux-x64-xlarge
+      dockerdWithinRunnerContainer: true
+      image: 724087766192.dkr.ecr.us-east-2.amazonaws.com/ci-zephyr-runner-arc:latest
+      resources:
+        limits:
+          cpu: "4.0"
+          memory: "8Gi"
+        requests:
+          cpu: "3.5"
+          memory: "5Gi"
+      volumeMounts:
+      - mountPath: "/repo-cache"
+        name: repo-cache
+        readOnly: true
+      - mountPath: "/var/lib/docker/image"
+        name: docker-image
+      - mountPath: "/var/lib/docker/overlay2"
+        name: docker-overlay2
+      volumes:
+      - name: repo-cache
+        hostPath:
+          path: /pod-cache/repos
+      - name: docker-image
+        hostPath:
+          path: /var/lib/docker-dind/image
+      - name: docker-overlay2
+        hostPath:
+          path: /var/lib/docker-dind/overlay2
+      nodeSelector:
+        instanceType: spot
+        instanceSize: xlarge
+        instanceArch: x64
+        instanceOs: linux
+      tolerations:
+      - key: "spotInstance"
+        operator: "Equal"
+        value: "true"
+        effect: "NoSchedule"
+---
+apiVersion: actions.summerwind.dev/v1alpha1
+kind: HorizontalRunnerAutoscaler
+metadata:
+  name: test-runner-linux-x64-xlarge-deployment-autoscaler
+  namespace: zephyr-runner
+spec:
+  scaleTargetRef:
+    kind: RunnerDeployment
+    name: test-runner-linux-x64-xlarge-deployment
+  minReplicas: 0
+  maxReplicas: 100
+  scaleDownDelaySecondsAfterScaleOut: 60
+  metrics:
+  - type: TotalNumberOfQueuedAndInProgressWorkflowRuns
+    repositoryNames:
+    - zephyr-testing

--- a/kubernetes/test-runner/test-runner-linux-x64-xlarge.yaml
+++ b/kubernetes/test-runner/test-runner-linux-x64-xlarge.yaml
@@ -63,3 +63,4 @@ spec:
   - type: TotalNumberOfQueuedAndInProgressWorkflowRuns
     repositoryNames:
     - zephyr-testing
+    - sdk-ng-testing

--- a/kubernetes/test-runner/test-runner.yaml
+++ b/kubernetes/test-runner/test-runner.yaml
@@ -37,7 +37,10 @@ spec:
         hostPath:
           path: /var/lib/docker-dind/overlay2
       nodeSelector:
-        InstanceType: spot
+        instanceType: spot
+        instanceSize: 4xlarge
+        instanceArch: x64
+        instanceOs: linux
       tolerations:
       - key: "spotInstance"
         operator: "Equal"

--- a/kubernetes/zephyr-runner/zephyr-runner-linux-arm64-4xlarge.yaml
+++ b/kubernetes/zephyr-runner/zephyr-runner-linux-arm64-4xlarge.yaml
@@ -12,7 +12,7 @@ spec:
       - 4xlarge
       - zephyr-runner-linux-arm64-4xlarge
       dockerdWithinRunnerContainer: true
-      image: 724087766192.dkr.ecr.us-east-2.amazonaws.com/ci-zephyr-runner-arc:v0.0.8
+      image: 724087766192.dkr.ecr.us-east-2.amazonaws.com/ci-zephyr-runner-arc:v0.0.9
       resources:
         limits:
           cpu: "16.0"

--- a/kubernetes/zephyr-runner/zephyr-runner-linux-arm64-4xlarge.yaml
+++ b/kubernetes/zephyr-runner/zephyr-runner-linux-arm64-4xlarge.yaml
@@ -1,0 +1,70 @@
+apiVersion: actions.summerwind.dev/v1alpha1
+kind: RunnerDeployment
+metadata:
+  name: zephyr-runner-linux-arm64-4xlarge-deployment
+  namespace: zephyr-runner
+spec:
+  template:
+    spec:
+      organization: zephyrproject-rtos
+      labels:
+      - zephyr-runner
+      - 4xlarge
+      - zephyr-runner-linux-arm64-4xlarge
+      dockerdWithinRunnerContainer: true
+      image: 724087766192.dkr.ecr.us-east-2.amazonaws.com/ci-zephyr-runner-arc:v0.0.8
+      resources:
+        limits:
+          cpu: "16.0"
+          memory: "32Gi"
+        requests:
+          cpu: "15.0"
+          memory: "24Gi"
+      volumeMounts:
+      - mountPath: "/repo-cache"
+        name: repo-cache
+        readOnly: true
+      - mountPath: "/var/lib/docker/image"
+        name: docker-image
+      - mountPath: "/var/lib/docker/overlay2"
+        name: docker-overlay2
+      volumes:
+      - name: repo-cache
+        hostPath:
+          path: /pod-cache/repos
+      - name: docker-image
+        hostPath:
+          path: /var/lib/docker-dind/image
+      - name: docker-overlay2
+        hostPath:
+          path: /var/lib/docker-dind/overlay2
+      nodeSelector:
+        instanceType: spot
+        instanceSize: 4xlarge
+        instanceArch: arm64
+        instanceOs: linux
+      tolerations:
+      - key: "spotInstance"
+        operator: "Equal"
+        value: "true"
+        effect: "NoSchedule"
+---
+apiVersion: actions.summerwind.dev/v1alpha1
+kind: HorizontalRunnerAutoscaler
+metadata:
+  name: zephyr-runner-linux-arm64-4xlarge-deployment-autoscaler
+  namespace: zephyr-runner
+spec:
+  scaleTargetRef:
+    kind: RunnerDeployment
+    name: zephyr-runner-linux-arm64-4xlarge-deployment
+  minReplicas: 0
+  maxReplicas: 100
+  scaleDownDelaySecondsAfterScaleOut: 60
+  metrics:
+  - type: TotalNumberOfQueuedAndInProgressWorkflowRuns
+    repositoryNames:
+    - zephyr
+    - zephyr-bt-sig
+    - sdk-ng
+    - docker-image

--- a/kubernetes/zephyr-runner/zephyr-runner-linux-arm64-xlarge.yaml
+++ b/kubernetes/zephyr-runner/zephyr-runner-linux-arm64-xlarge.yaml
@@ -12,7 +12,7 @@ spec:
       - xlarge
       - zephyr-runner-linux-arm64-xlarge
       dockerdWithinRunnerContainer: true
-      image: 724087766192.dkr.ecr.us-east-2.amazonaws.com/ci-zephyr-runner-arc:v0.0.8
+      image: 724087766192.dkr.ecr.us-east-2.amazonaws.com/ci-zephyr-runner-arc:v0.0.9
       resources:
         limits:
           cpu: "4.0"

--- a/kubernetes/zephyr-runner/zephyr-runner-linux-arm64-xlarge.yaml
+++ b/kubernetes/zephyr-runner/zephyr-runner-linux-arm64-xlarge.yaml
@@ -1,0 +1,70 @@
+apiVersion: actions.summerwind.dev/v1alpha1
+kind: RunnerDeployment
+metadata:
+  name: zephyr-runner-linux-arm64-xlarge-deployment
+  namespace: zephyr-runner
+spec:
+  template:
+    spec:
+      organization: zephyrproject-rtos
+      labels:
+      - zephyr-runner
+      - xlarge
+      - zephyr-runner-linux-arm64-xlarge
+      dockerdWithinRunnerContainer: true
+      image: 724087766192.dkr.ecr.us-east-2.amazonaws.com/ci-zephyr-runner-arc:v0.0.8
+      resources:
+        limits:
+          cpu: "4.0"
+          memory: "8Gi"
+        requests:
+          cpu: "3.5"
+          memory: "5Gi"
+      volumeMounts:
+      - mountPath: "/repo-cache"
+        name: repo-cache
+        readOnly: true
+      - mountPath: "/var/lib/docker/image"
+        name: docker-image
+      - mountPath: "/var/lib/docker/overlay2"
+        name: docker-overlay2
+      volumes:
+      - name: repo-cache
+        hostPath:
+          path: /pod-cache/repos
+      - name: docker-image
+        hostPath:
+          path: /var/lib/docker-dind/image
+      - name: docker-overlay2
+        hostPath:
+          path: /var/lib/docker-dind/overlay2
+      nodeSelector:
+        instanceType: spot
+        instanceSize: xlarge
+        instanceArch: arm64
+        instanceOs: linux
+      tolerations:
+      - key: "spotInstance"
+        operator: "Equal"
+        value: "true"
+        effect: "NoSchedule"
+---
+apiVersion: actions.summerwind.dev/v1alpha1
+kind: HorizontalRunnerAutoscaler
+metadata:
+  name: zephyr-runner-linux-arm64-xlarge-deployment-autoscaler
+  namespace: zephyr-runner
+spec:
+  scaleTargetRef:
+    kind: RunnerDeployment
+    name: zephyr-runner-linux-arm64-xlarge-deployment
+  minReplicas: 0
+  maxReplicas: 100
+  scaleDownDelaySecondsAfterScaleOut: 60
+  metrics:
+  - type: TotalNumberOfQueuedAndInProgressWorkflowRuns
+    repositoryNames:
+    - zephyr
+    - zephyr-bt-sig
+    - sdk-ng
+    - docker-image

--- a/kubernetes/zephyr-runner/zephyr-runner-linux-x64-4xlarge.yaml
+++ b/kubernetes/zephyr-runner/zephyr-runner-linux-x64-4xlarge.yaml
@@ -12,7 +12,7 @@ spec:
       - 4xlarge
       - zephyr-runner-linux-x64-4xlarge
       dockerdWithinRunnerContainer: true
-      image: 724087766192.dkr.ecr.us-east-2.amazonaws.com/ci-zephyr-runner-arc:v0.0.8
+      image: 724087766192.dkr.ecr.us-east-2.amazonaws.com/ci-zephyr-runner-arc:v0.0.9
       resources:
         limits:
           cpu: "16.0"

--- a/kubernetes/zephyr-runner/zephyr-runner-linux-x64-4xlarge.yaml
+++ b/kubernetes/zephyr-runner/zephyr-runner-linux-x64-4xlarge.yaml
@@ -41,6 +41,8 @@ spec:
       nodeSelector:
         instanceType: spot
         instanceSize: 4xlarge
+        instanceArch: x64
+        instanceOs: linux
       tolerations:
       - key: "spotInstance"
         operator: "Equal"

--- a/kubernetes/zephyr-runner/zephyr-runner-linux-x64-xlarge.yaml
+++ b/kubernetes/zephyr-runner/zephyr-runner-linux-x64-xlarge.yaml
@@ -41,6 +41,8 @@ spec:
       nodeSelector:
         instanceType: spot
         instanceSize: xlarge
+        instanceArch: x64
+        instanceOs: linux
       tolerations:
       - key: "spotInstance"
         operator: "Equal"

--- a/kubernetes/zephyr-runner/zephyr-runner-linux-x64-xlarge.yaml
+++ b/kubernetes/zephyr-runner/zephyr-runner-linux-x64-xlarge.yaml
@@ -12,7 +12,7 @@ spec:
       - xlarge
       - zephyr-runner-linux-x64-xlarge
       dockerdWithinRunnerContainer: true
-      image: 724087766192.dkr.ecr.us-east-2.amazonaws.com/ci-zephyr-runner-arc:v0.0.8
+      image: 724087766192.dkr.ecr.us-east-2.amazonaws.com/ci-zephyr-runner-arc:v0.0.9
       resources:
         limits:
           cpu: "4.0"

--- a/terraform/zephyr-alpha/main.tf
+++ b/terraform/zephyr-alpha/main.tf
@@ -29,6 +29,10 @@ module "zephyr_aws_blueprints" {
   mng_spot_linux_x64_4xlarge_max_size     = 100
   mng_spot_linux_x64_4xlarge_desired_size = 1
 
+  mng_spot_linux_arm64_xlarge_min_size     = 0
+  mng_spot_linux_arm64_xlarge_max_size     = 100
+  mng_spot_linux_arm64_xlarge_desired_size = 1
+
   github_organization = "zephyrproject-rtos"
 
   kube_prometheus_stack_grafana_password = var.kube_prometheus_stack_grafana_password

--- a/terraform/zephyr-alpha/main.tf
+++ b/terraform/zephyr-alpha/main.tf
@@ -17,17 +17,17 @@ module "zephyr_aws_blueprints" {
     }
   ]
 
-  mng_od_8vcpu_16mem_min_size     = 1
-  mng_od_8vcpu_16mem_max_size     = 2
-  mng_od_8vcpu_16mem_desired_size = 2
+  mng_od_linux_x64_2xlarge_min_size     = 1
+  mng_od_linux_x64_2xlarge_max_size     = 2
+  mng_od_linux_x64_2xlarge_desired_size = 2
 
-  mng_spot_4vcpu_8mem_min_size     = 0
-  mng_spot_4vcpu_8mem_max_size     = 100
-  mng_spot_4vcpu_8mem_desired_size = 1
+  mng_spot_linux_x64_xlarge_min_size     = 0
+  mng_spot_linux_x64_xlarge_max_size     = 100
+  mng_spot_linux_x64_xlarge_desired_size = 1
 
-  mng_spot_16vcpu_32mem_min_size     = 0
-  mng_spot_16vcpu_32mem_max_size     = 100
-  mng_spot_16vcpu_32mem_desired_size = 1
+  mng_spot_linux_x64_4xlarge_min_size     = 0
+  mng_spot_linux_x64_4xlarge_max_size     = 100
+  mng_spot_linux_x64_4xlarge_desired_size = 1
 
   github_organization = "zephyrproject-rtos"
 

--- a/terraform/zephyr-alpha/main.tf
+++ b/terraform/zephyr-alpha/main.tf
@@ -33,6 +33,10 @@ module "zephyr_aws_blueprints" {
   mng_spot_linux_arm64_xlarge_max_size     = 100
   mng_spot_linux_arm64_xlarge_desired_size = 1
 
+  mng_spot_linux_arm64_4xlarge_min_size     = 0
+  mng_spot_linux_arm64_4xlarge_max_size     = 100
+  mng_spot_linux_arm64_4xlarge_desired_size = 1
+
   github_organization = "zephyrproject-rtos"
 
   kube_prometheus_stack_grafana_password = var.kube_prometheus_stack_grafana_password

--- a/terraform/zephyr-alpha/main.tf
+++ b/terraform/zephyr-alpha/main.tf
@@ -50,4 +50,6 @@ module "zephyr_aws_blueprints" {
 
   enable_zephyr_runner_linux_x64_xlarge = true
   enable_zephyr_runner_linux_x64_4xlarge = true
+  enable_zephyr_runner_linux_arm64_xlarge = true
+  enable_zephyr_runner_linux_arm64_4xlarge = true
 }

--- a/terraform/zephyr-aws-blueprints/main.tf
+++ b/terraform/zephyr-aws-blueprints/main.tf
@@ -783,3 +783,27 @@ resource "kubectl_manifest" "zephyr_runner_linux_x64_4xlarge_manifest" {
   wait       = true
   depends_on = [kubernetes_namespace.zephyr_runner_namespace]
 }
+
+# zephyr-runner-linux-arm64-xlarge Kubernetes Deployment
+data "kubectl_path_documents" "zephyr_runner_linux_arm64_xlarge_manifests" {
+  pattern = "../../kubernetes/zephyr-runner/zephyr-runner-linux-arm64-xlarge.yaml"
+}
+
+resource "kubectl_manifest" "zephyr_runner_linux_arm64_xlarge_manifest" {
+  count      = var.enable_zephyr_runner_linux_arm64_xlarge ? length(data.kubectl_path_documents.zephyr_runner_linux_arm64_xlarge_manifests.documents) : 0
+  yaml_body  = element(data.kubectl_path_documents.zephyr_runner_linux_arm64_xlarge_manifests.documents, count.index)
+  wait       = true
+  depends_on = [kubernetes_namespace.zephyr_runner_namespace]
+}
+
+# zephyr-runner-linux-arm64-4xlarge Kubernetes Deployment
+data "kubectl_path_documents" "zephyr_runner_linux_arm64_4xlarge_manifests" {
+  pattern = "../../kubernetes/zephyr-runner/zephyr-runner-linux-arm64-4xlarge.yaml"
+}
+
+resource "kubectl_manifest" "zephyr_runner_linux_arm64_4xlarge_manifest" {
+  count      = var.enable_zephyr_runner_linux_arm64_4xlarge ? length(data.kubectl_path_documents.zephyr_runner_linux_arm64_4xlarge_manifests.documents) : 0
+  yaml_body  = element(data.kubectl_path_documents.zephyr_runner_linux_arm64_4xlarge_manifests.documents, count.index)
+  wait       = true
+  depends_on = [kubernetes_namespace.zephyr_runner_namespace]
+}

--- a/terraform/zephyr-aws-blueprints/main.tf
+++ b/terraform/zephyr-aws-blueprints/main.tf
@@ -166,6 +166,8 @@ module "eks_blueprints" {
       k8s_labels = {
         instanceType = "on-demand"
         instanceSize = "2xlarge"
+        instanceArch = "x64"
+        instanceOs   = "linux"
       }
 
       # Node Group scaling configuration
@@ -214,6 +216,8 @@ module "eks_blueprints" {
       k8s_labels = {
         instanceType = "spot"
         instanceSize = "xlarge"
+        instanceArch = "x64"
+        instanceOs   = "linux"
       }
 
       # NOTE: If we want the node group to scale-down to zero nodes,
@@ -241,6 +245,8 @@ module "eks_blueprints" {
         "k8s.io/cluster-autoscaler/node-template/label/eks/node_group_name"            = "mng-spot-linux-x64-xlarge"
         "k8s.io/cluster-autoscaler/node-template/label/instanceType"                   = "spot"
         "k8s.io/cluster-autoscaler/node-template/label/instanceSize"                   = "large"
+        "k8s.io/cluster-autoscaler/node-template/label/instanceArch"                   = "x64"
+        "k8s.io/cluster-autoscaler/node-template/label/instanceOs"                     = "linux"
       }
     }
 
@@ -264,6 +270,8 @@ module "eks_blueprints" {
       k8s_labels = {
         instanceType = "spot"
         instanceSize = "4xlarge"
+        instanceArch = "x64"
+        instanceOs   = "linux"
       }
 
       # NOTE: If we want the node group to scale-down to zero nodes,
@@ -291,6 +299,8 @@ module "eks_blueprints" {
         "k8s.io/cluster-autoscaler/node-template/label/eks/node_group_name"            = "mng-spot-linux-x64-4xlarge"
         "k8s.io/cluster-autoscaler/node-template/label/instanceType"                   = "spot"
         "k8s.io/cluster-autoscaler/node-template/label/instanceSize"                   = "4xlarge"
+        "k8s.io/cluster-autoscaler/node-template/label/instanceArch"                   = "x64"
+        "k8s.io/cluster-autoscaler/node-template/label/instanceOs"                     = "linux"
       }
     }
   }

--- a/terraform/zephyr-aws-blueprints/main.tf
+++ b/terraform/zephyr-aws-blueprints/main.tf
@@ -42,12 +42,23 @@ data "aws_ami" "amazonlinux2eks" {
   owners = ["amazon"]
 }
 
-data "aws_ami" "zephyr_runner_node" {
+data "aws_ami" "zephyr_runner_node_x86_64" {
   most_recent = true
 
   filter {
     name   = "name"
-    values = ["zephyr-runner-node-*"]
+    values = ["zephyr-runner-node-x86_64-*"]
+  }
+
+  owners = ["724087766192"]
+}
+
+data "aws_ami" "zephyr_runner_node_arm64" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["zephyr-runner-node-arm64-*"]
   }
 
   owners = ["724087766192"]
@@ -188,7 +199,7 @@ module "eks_blueprints" {
       node_group_name = "mng-spot-4vcpu-8mem"
 
       ami_type        = "CUSTOM"
-      custom_ami_id   = data.aws_ami.zephyr_runner_node.id
+      custom_ami_id   = data.aws_ami.zephyr_runner_node_x86_64.id
       capacity_type   = "SPOT"
       instance_types  = ["c5a.xlarge", "c6a.xlarge"]
 
@@ -238,7 +249,7 @@ module "eks_blueprints" {
       node_group_name = "mng-spot-16vcpu-32mem"
 
       ami_type        = "CUSTOM"
-      custom_ami_id   = data.aws_ami.zephyr_runner_node.id
+      custom_ami_id   = data.aws_ami.zephyr_runner_node_x86_64.id
       capacity_type   = "SPOT"
       instance_types  = ["c5a.4xlarge", "c6a.4xlarge"]
 

--- a/terraform/zephyr-aws-blueprints/main.tf
+++ b/terraform/zephyr-aws-blueprints/main.tf
@@ -129,10 +129,10 @@ module "eks_blueprints" {
 
   # Node group configurations
   managed_node_groups = {
-    # On-demand general-purpose instances with 8 vCPUs and 16GiB memory 
-    od_8vcpu_16mem = {
+    # On-demand general-purpose x86-64 Linux instances with 8 vCPUs and 16 GiB memory
+    od_linux_x64_2xlarge = {
       # Node Group configuration
-      node_group_name = "mng-od-8vcpu-16mem" # Max 40 characters for node group name
+      node_group_name = "mng-od-linux-x64-2xlarge" # Max 40 characters for node group name
 
       ami_type               = "AL2_x86_64"    # Available options -> AL2_x86_64, AL2_x86_64_GPU, AL2_ARM_64, CUSTOM
       release_version        = ""              # Enter AMI release version to deploy the latest AMI released by AWS. Used only when you specify ami_type
@@ -169,9 +169,9 @@ module "eks_blueprints" {
       }
 
       # Node Group scaling configuration
-      desired_size = var.mng_od_8vcpu_16mem_desired_size
-      max_size     = var.mng_od_8vcpu_16mem_max_size
-      min_size     = var.mng_od_8vcpu_16mem_min_size
+      desired_size = var.mng_od_linux_x64_2xlarge_desired_size
+      max_size     = var.mng_od_linux_x64_2xlarge_max_size
+      min_size     = var.mng_od_linux_x64_2xlarge_min_size
 
       # Block device configuration
       block_device_mappings = [
@@ -194,9 +194,9 @@ module "eks_blueprints" {
       ssh_security_group_id = ""
     }
 
-    # Spot instances with 4 vCPU and 8 GiB memory
-    spot_4vcpu_8mem = {
-      node_group_name = "mng-spot-4vcpu-8mem"
+    # Spot x86-64 Linux instances with 4 vCPU and 8 GiB memory
+    spot_linux_x64_xlarge = {
+      node_group_name = "mng-spot-linux-x64-xlarge"
 
       ami_type        = "CUSTOM"
       custom_ami_id   = data.aws_ami.zephyr_runner_node_x86_64.id
@@ -218,9 +218,9 @@ module "eks_blueprints" {
 
       # NOTE: If we want the node group to scale-down to zero nodes,
       # we need to use a custom launch template and define some additional tags for the ASGs
-      desired_size = var.mng_spot_4vcpu_8mem_desired_size
-      max_size     = var.mng_spot_4vcpu_8mem_max_size
-      min_size     = var.mng_spot_4vcpu_8mem_min_size
+      desired_size = var.mng_spot_linux_x64_xlarge_desired_size
+      max_size     = var.mng_spot_linux_x64_xlarge_max_size
+      min_size     = var.mng_spot_linux_x64_xlarge_min_size
 
       # Block device configuration
       block_device_mappings = [
@@ -238,15 +238,15 @@ module "eks_blueprints" {
       # This is so cluster autoscaler can identify which node (using ASGs tags) to scale-down to zero nodes
       additional_tags = {
         "k8s.io/cluster-autoscaler/node-template/label/eks.amazonaws.com/capacityType" = "SPOT"
-        "k8s.io/cluster-autoscaler/node-template/label/eks/node_group_name"            = "mng-spot-4vcpu-8mem"
+        "k8s.io/cluster-autoscaler/node-template/label/eks/node_group_name"            = "mng-spot-linux-x64-xlarge"
         "k8s.io/cluster-autoscaler/node-template/label/instanceType"                   = "spot"
         "k8s.io/cluster-autoscaler/node-template/label/instanceSize"                   = "large"
       }
     }
 
-    # Spot instances with 16 vCPUs and 32 GiB memory
-    spot_16vcpu_32mem = {
-      node_group_name = "mng-spot-16vcpu-32mem"
+    # Spot x86-64 Linux instances with 16 vCPUs and 32 GiB memory
+    spot_linux_x64_4xlarge = {
+      node_group_name = "mng-spot-linux-x64-4xlarge"
 
       ami_type        = "CUSTOM"
       custom_ami_id   = data.aws_ami.zephyr_runner_node_x86_64.id
@@ -268,9 +268,9 @@ module "eks_blueprints" {
 
       # NOTE: If we want the node group to scale-down to zero nodes,
       # we need to use a custom launch template and define some additional tags for the ASGs
-      desired_size = var.mng_spot_16vcpu_32mem_desired_size
-      max_size     = var.mng_spot_16vcpu_32mem_max_size
-      min_size     = var.mng_spot_16vcpu_32mem_min_size
+      desired_size = var.mng_spot_linux_x64_4xlarge_desired_size
+      max_size     = var.mng_spot_linux_x64_4xlarge_max_size
+      min_size     = var.mng_spot_linux_x64_4xlarge_min_size
 
       # Block device configuration
       block_device_mappings = [
@@ -288,7 +288,7 @@ module "eks_blueprints" {
       # This is so cluster autoscaler can identify which node (using ASGs tags) to scale-down to zero nodes
       additional_tags = {
         "k8s.io/cluster-autoscaler/node-template/label/eks.amazonaws.com/capacityType" = "SPOT"
-        "k8s.io/cluster-autoscaler/node-template/label/eks/node_group_name"            = "mng-spot-16vcpu-32mem"
+        "k8s.io/cluster-autoscaler/node-template/label/eks/node_group_name"            = "mng-spot-linux-x64-4xlarge"
         "k8s.io/cluster-autoscaler/node-template/label/instanceType"                   = "spot"
         "k8s.io/cluster-autoscaler/node-template/label/instanceSize"                   = "4xlarge"
       }
@@ -350,9 +350,9 @@ module "eks_blueprints_kubernetes_addons" {
         name  = "expanderPriorities"
         value = <<-EOT
                   100:
-                    - .*-spot-4vcpu-8mem.*
+                    - .*-spot-linux-x64-xlarge.*
                   90:
-                    - .*-spot-16vcpu-32mem.*
+                    - .*-spot-linux-x64-4xlarge.*
                   10:
                     - .*
                 EOT

--- a/terraform/zephyr-aws-blueprints/main.tf
+++ b/terraform/zephyr-aws-blueprints/main.tf
@@ -350,9 +350,7 @@ module "eks_blueprints_kubernetes_addons" {
         name  = "expanderPriorities"
         value = <<-EOT
                   100:
-                    - .*-spot-linux-x64-xlarge.*
-                  90:
-                    - .*-spot-linux-x64-4xlarge.*
+                    - .*-spot-.*
                   10:
                     - .*
                 EOT

--- a/terraform/zephyr-aws-blueprints/main.tf
+++ b/terraform/zephyr-aws-blueprints/main.tf
@@ -357,6 +357,60 @@ module "eks_blueprints" {
         "k8s.io/cluster-autoscaler/node-template/label/instanceOs"                     = "linux"
       }
     }
+
+    # Spot ARM64 Linux instances with 16 vCPUs and 32 GiB memory
+    spot_linux_arm64_4xlarge = {
+      node_group_name = "mng-spot-linux-arm64-4xlarge"
+
+      ami_type        = "CUSTOM"
+      custom_ami_id   = data.aws_ami.zephyr_runner_node_arm64.id
+      capacity_type   = "SPOT"
+      instance_types  = ["c7g.4xlarge"] # "c6g.4xlarge", "c6gn.4xlarge"
+
+      # Node Group network configuration
+      subnet_type = "private" # public or private - Default uses the private subnets used in control plane if you don't pass the "subnet_ids"
+      subnet_ids  = []        # Defaults to private subnet-ids used by EKS Control plane. Define your private/public subnets list with comma separated subnet_ids  = ['subnet1','subnet2','subnet3']
+
+      # Node taints
+      k8s_taints = [{ key = "spotInstance", value = "true", effect = "NO_SCHEDULE" }]
+
+      # Node label configuration
+      k8s_labels = {
+        instanceType = "spot"
+        instanceSize = "4xlarge"
+        instanceArch = "arm64"
+        instanceOs   = "linux"
+      }
+
+      # NOTE: If we want the node group to scale-down to zero nodes,
+      # we need to use a custom launch template and define some additional tags for the ASGs
+      desired_size = var.mng_spot_linux_arm64_4xlarge_desired_size
+      max_size     = var.mng_spot_linux_arm64_4xlarge_max_size
+      min_size     = var.mng_spot_linux_arm64_4xlarge_min_size
+
+      # Block device configuration
+      block_device_mappings = [
+        {
+          device_name = "/dev/xvda"
+          volume_type = "gp3"
+          volume_size = 150
+        }
+      ]
+
+      # Launch template configuration
+      create_launch_template = true              # false will use the default launch template
+      launch_template_os     = "amazonlinux2eks" # amazonlinux2eks or bottlerocket
+
+      # This is so cluster autoscaler can identify which node (using ASGs tags) to scale-down to zero nodes
+      additional_tags = {
+        "k8s.io/cluster-autoscaler/node-template/label/eks.amazonaws.com/capacityType" = "SPOT"
+        "k8s.io/cluster-autoscaler/node-template/label/eks/node_group_name"            = "mng-spot-linux-arm64-4xlarge"
+        "k8s.io/cluster-autoscaler/node-template/label/instanceType"                   = "spot"
+        "k8s.io/cluster-autoscaler/node-template/label/instanceSize"                   = "4xlarge"
+        "k8s.io/cluster-autoscaler/node-template/label/instanceArch"                   = "arm64"
+        "k8s.io/cluster-autoscaler/node-template/label/instanceOs"                     = "linux"
+      }
+    }
   }
 
   tags = local.tags

--- a/terraform/zephyr-aws-blueprints/variables.tf
+++ b/terraform/zephyr-aws-blueprints/variables.tf
@@ -74,6 +74,24 @@ variable "mng_spot_linux_x64_4xlarge_desired_size" {
   default     = 1
 }
 
+variable "mng_spot_linux_arm64_xlarge_min_size" {
+  description = "Minimum number of nodes for Linux ARM64 xlarge spot instance managed node group"
+  type        = number
+  default     = 0
+}
+
+variable "mng_spot_linux_arm64_xlarge_max_size" {
+  description = "Maximum number of nodes for Linux ARM64 xlarge spot instance managed node group"
+  type        = number
+  default     = 100
+}
+
+variable "mng_spot_linux_arm64_xlarge_desired_size" {
+  description = "Desired number of nodes for Linux ARM64 xlarge spot instance managed node group"
+  type        = number
+  default     = 1
+}
+
 variable "github_organization" {
   description = "GitHub organization name"
   type        = string

--- a/terraform/zephyr-aws-blueprints/variables.tf
+++ b/terraform/zephyr-aws-blueprints/variables.tf
@@ -161,3 +161,15 @@ variable "enable_zephyr_runner_linux_x64_4xlarge" {
   type        = bool
   default     = false
 }
+
+variable "enable_zephyr_runner_linux_arm64_xlarge" {
+  description = "Enable Zephyr Runner linux-arm64-xlarge"
+  type        = bool
+  default     = false
+}
+
+variable "enable_zephyr_runner_linux_arm64_4xlarge" {
+  description = "Enable Zephyr Runner linux-arm64-4xlarge"
+  type        = bool
+  default     = false
+}

--- a/terraform/zephyr-aws-blueprints/variables.tf
+++ b/terraform/zephyr-aws-blueprints/variables.tf
@@ -92,6 +92,24 @@ variable "mng_spot_linux_arm64_xlarge_desired_size" {
   default     = 1
 }
 
+variable "mng_spot_linux_arm64_4xlarge_min_size" {
+  description = "Minimum number of nodes for Linux ARM64 4xlarge spot instance managed node group"
+  type        = number
+  default     = 0
+}
+
+variable "mng_spot_linux_arm64_4xlarge_max_size" {
+  description = "Maximum number of nodes for Linux ARM64 4xlarge spot instance managed node group"
+  type        = number
+  default     = 100
+}
+
+variable "mng_spot_linux_arm64_4xlarge_desired_size" {
+  description = "Desired number of nodes for Linux ARM64 4xlarge spot instance managed node group"
+  type        = number
+  default     = 1
+}
+
 variable "github_organization" {
   description = "GitHub organization name"
   type        = string

--- a/terraform/zephyr-aws-blueprints/variables.tf
+++ b/terraform/zephyr-aws-blueprints/variables.tf
@@ -20,56 +20,56 @@ variable "aws_auth_map_users" {
   default = []
 }
 
-variable "mng_od_8vcpu_16mem_min_size" {
-  description = "Minimum number of nodes for 8 vCPU 16 GiB memory on-demand instance managed node group"
+variable "mng_od_linux_x64_2xlarge_min_size" {
+  description = "Minimum number of nodes for Linux x86-64 2xlarge on-demand instance managed node group"
   type        = number
   default     = 1
 }
 
-variable "mng_od_8vcpu_16mem_max_size" {
-  description = "Maximum number of nodes for 8 vCPU 16 GiB memory on-demand instance managed node group"
+variable "mng_od_linux_x64_2xlarge_max_size" {
+  description = "Maximum number of nodes for Linux x86-64 2xlarge on-demand instance managed node group"
   type        = number
   default     = 10
 }
 
-variable "mng_od_8vcpu_16mem_desired_size" {
-  description = "Desired number of nodes for 8 vCPU 16 GiB memory on-demand instance managed node group"
+variable "mng_od_linux_x64_2xlarge_desired_size" {
+  description = "Desired number of nodes for Linux x86-64 2xlarge on-demand instance managed node group"
   type        = number
   default     = 2
 }
 
-variable "mng_spot_4vcpu_8mem_min_size" {
-  description = "Minimum number of nodes for 4 vCPU 8 GiB memory spot instance managed node group"
+variable "mng_spot_linux_x64_xlarge_min_size" {
+  description = "Minimum number of nodes for Linux x86-64 xlarge spot instance managed node group"
   type        = number
   default     = 0
 }
 
-variable "mng_spot_4vcpu_8mem_max_size" {
-  description = "Maximum number of nodes for 4 vCPU 8 GiB memory spot instance managed node group"
+variable "mng_spot_linux_x64_xlarge_max_size" {
+  description = "Maximum number of nodes for Linux x86-64 xlarge spot instance managed node group"
   type        = number
   default     = 100
 }
 
-variable "mng_spot_4vcpu_8mem_desired_size" {
-  description = "Desired number of nodes for 4 vCPU 8 GiB memory spot instance managed node group"
+variable "mng_spot_linux_x64_xlarge_desired_size" {
+  description = "Desired number of nodes for Linux x86-64 xlarge spot instance managed node group"
   type        = number
   default     = 1
 }
 
-variable "mng_spot_16vcpu_32mem_min_size" {
-  description = "Minimum number of nodes for 16 vCPU 32 GiB memory spot instance managed node group"
+variable "mng_spot_linux_x64_4xlarge_min_size" {
+  description = "Minimum number of nodes for Linux x86-64 4xlarge spot instance managed node group"
   type        = number
   default     = 0
 }
 
-variable "mng_spot_16vcpu_32mem_max_size" {
-  description = "Maximum number of nodes for 16 vCPU 32 GiB memory spot instance managed node group"
+variable "mng_spot_linux_x64_4xlarge_max_size" {
+  description = "Maximum number of nodes for Linux x86-64 4xlarge spot instance managed node group"
   type        = number
   default     = 100
 }
 
-variable "mng_spot_16vcpu_32mem_desired_size" {
-  description = "Desired number of nodes for 16 vCPU 32 GiB memory spot instance managed node group"
+variable "mng_spot_linux_x64_4xlarge_desired_size" {
+  description = "Desired number of nodes for Linux x86-64 4xlarge spot instance managed node group"
   type        = number
   default     = 1
 }

--- a/terraform/zephyr-beta/main.tf
+++ b/terraform/zephyr-beta/main.tf
@@ -17,17 +17,17 @@ module "zephyr_aws_blueprints" {
     }
   ]
 
-  mng_od_8vcpu_16mem_min_size     = 1
-  mng_od_8vcpu_16mem_max_size     = 1
-  mng_od_8vcpu_16mem_desired_size = 1
+  mng_od_linux_x64_2xlarge_min_size     = 1
+  mng_od_linux_x64_2xlarge_max_size     = 1
+  mng_od_linux_x64_2xlarge_desired_size = 1
 
-  mng_spot_4vcpu_8mem_min_size     = 0
-  mng_spot_4vcpu_8mem_max_size     = 100
-  mng_spot_4vcpu_8mem_desired_size = 1
+  mng_spot_linux_x64_xlarge_min_size     = 0
+  mng_spot_linux_x64_xlarge_max_size     = 100
+  mng_spot_linux_x64_xlarge_desired_size = 1
 
-  mng_spot_16vcpu_32mem_min_size     = 0
-  mng_spot_16vcpu_32mem_max_size     = 100
-  mng_spot_16vcpu_32mem_desired_size = 1
+  mng_spot_linux_x64_4xlarge_min_size     = 0
+  mng_spot_linux_x64_4xlarge_max_size     = 100
+  mng_spot_linux_x64_4xlarge_desired_size = 1
 
   github_organization = "zephyrproject-rtos"
 

--- a/terraform/zephyr-beta/main.tf
+++ b/terraform/zephyr-beta/main.tf
@@ -29,6 +29,10 @@ module "zephyr_aws_blueprints" {
   mng_spot_linux_x64_4xlarge_max_size     = 100
   mng_spot_linux_x64_4xlarge_desired_size = 1
 
+  mng_spot_linux_arm64_xlarge_min_size     = 0
+  mng_spot_linux_arm64_xlarge_max_size     = 100
+  mng_spot_linux_arm64_xlarge_desired_size = 1
+
   github_organization = "zephyrproject-rtos"
 
   kube_prometheus_stack_grafana_password = var.kube_prometheus_stack_grafana_password

--- a/terraform/zephyr-beta/main.tf
+++ b/terraform/zephyr-beta/main.tf
@@ -50,4 +50,6 @@ module "zephyr_aws_blueprints" {
 
   enable_zephyr_runner_linux_x64_xlarge = false
   enable_zephyr_runner_linux_x64_4xlarge = false
+  enable_zephyr_runner_linux_arm64_xlarge = false
+  enable_zephyr_runner_linux_arm64_4xlarge = false
 }

--- a/terraform/zephyr-beta/main.tf
+++ b/terraform/zephyr-beta/main.tf
@@ -33,6 +33,10 @@ module "zephyr_aws_blueprints" {
   mng_spot_linux_arm64_xlarge_max_size     = 100
   mng_spot_linux_arm64_xlarge_desired_size = 1
 
+  mng_spot_linux_arm64_4xlarge_min_size     = 0
+  mng_spot_linux_arm64_4xlarge_max_size     = 100
+  mng_spot_linux_arm64_4xlarge_desired_size = 1
+
   github_organization = "zephyrproject-rtos"
 
   kube_prometheus_stack_grafana_password = var.kube_prometheus_stack_grafana_password


### PR DESCRIPTION
This series adds:

* Kubernetes node groups for ARM64 instances
* ARC test-runner deployments for ARM64 runners
* ARC zephyr-runner deployments for ARM64 runners