### PR TITLE
zephyr-aws-blueprints: Increase 4xlarge node volume size to 200GB

### DIFF
--- a/terraform/zephyr-aws-blueprints/main.tf
+++ b/terraform/zephyr-aws-blueprints/main.tf
@@ -285,7 +285,7 @@ module "eks_blueprints" {
         {
           device_name = "/dev/xvda"
           volume_type = "gp3"
-          volume_size = 150
+          volume_size = 200
         }
       ]
 
@@ -393,7 +393,7 @@ module "eks_blueprints" {
         {
           device_name = "/dev/xvda"
           volume_type = "gp3"
-          volume_size = 150
+          volume_size = 200
         }
       ]
 


### PR DESCRIPTION
This commit increases the default volume size of the 4xlarge nodes from 150GB to 200GB because some workloads, such as the sdk-ng build, require more disk space.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>