### PR TITLE
zephyr-aws-blueprints: Designate specific AMI version

### DIFF
--- a/terraform/zephyr-aws-blueprints/main.tf
+++ b/terraform/zephyr-aws-blueprints/main.tf
@@ -47,7 +47,7 @@ data "aws_ami" "zephyr_runner_node_x86_64" {
 
   filter {
     name   = "name"
-    values = ["zephyr-runner-node-x86_64-*"]
+    values = ["zephyr-runner-node-x86_64-1669044340"]
   }
 
   owners = ["724087766192"]
@@ -58,7 +58,7 @@ data "aws_ami" "zephyr_runner_node_arm64" {
 
   filter {
     name   = "name"
-    values = ["zephyr-runner-node-arm64-*"]
+    values = ["zephyr-runner-node-arm64-1669044291"]
   }
 
   owners = ["724087766192"]


### PR DESCRIPTION
This commit updates the Terraform EKS configurations to designate a specific version of AMI to use instead of picking the latest version available at the time of running `terraform apply`.

The purpose of this is to prevent any unintentional AMI changes that could lead to unpredictable behaviours.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>