### PR TITLE
zephyr-alpha: Increase maximum on-demand node count to 4

### DIFF
--- a/terraform/zephyr-alpha/main.tf
+++ b/terraform/zephyr-alpha/main.tf
@@ -18,7 +18,7 @@ module "zephyr_aws_blueprints" {
   ]
 
   mng_od_linux_x64_2xlarge_min_size     = 1
-  mng_od_linux_x64_2xlarge_max_size     = 2
+  mng_od_linux_x64_2xlarge_max_size     = 4
   mng_od_linux_x64_2xlarge_desired_size = 2
 
   mng_spot_linux_x64_xlarge_min_size     = 0


### PR DESCRIPTION
This commit increases the maximum number of the primary on-demand nodes from 2 to 4 in preparation for the upcoming Elastic stack deployment.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>