### PR TITLE
elastic-stack-main: Enable Kibana anonymous authentication

### DIFF
--- a/kubernetes/elastic-stack-main/kibana.yaml
+++ b/kubernetes/elastic-stack-main/kibana.yaml
@@ -8,6 +8,14 @@ spec:
   count: 2
   config:
     server.publicBaseUrl: https://kibana.zephyrproject.io
+    xpack.security.authc.providers:
+      basic.basic1:
+        order: 0
+      anonymous.anonymous1:
+        order: 1
+        credentials:
+          username: "guest"
+          password: "kibanaguest"
   elasticsearchRef:
     name: main
   podTemplate:


### PR DESCRIPTION
This commit enables an option to authenticate as a guest user without requiring a username and a password for Kibana.

The current "anonymous user" credential is "guest" user.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>