### PR TITLE
elastic-stack: Increase maximum HTTP request size to 100MB

### DIFF
--- a/kubernetes/elastic-stack-main/ingress.yaml
+++ b/kubernetes/elastic-stack-main/ingress.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    nginx.ingress.kubernetes.io/proxy-body-size: 100m
     cert-manager.io/cluster-issuer: cert-manager-letsencrypt-production
 spec:
   rules:

--- a/kubernetes/elastic-stack-staging/ingress.yaml
+++ b/kubernetes/elastic-stack-staging/ingress.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    nginx.ingress.kubernetes.io/proxy-body-size: 100m
     cert-manager.io/cluster-issuer: cert-manager-letsencrypt-production
 spec:
   rules:


### PR DESCRIPTION
This commit increases the maximum HTTP request size to the Elastic
Search ingress to 100MB, which is the default maximum allowed by the
Elastic Search node HTTP server.

This is necessary because the Zephyr main bi-weekly CI run result upload fails otherwise.