### PR TITLE
zephyr-runner-node: Update CI docker image versions

### DIFF
--- a/packer/zephyr-runner-node/script.sh
+++ b/packer/zephyr-runner-node/script.sh
@@ -13,8 +13,8 @@ sudo cp -R /var/lib/docker /var/lib/docker-orig
 sudo systemctl start docker
 
 # Cache CI Docker images
-docker pull ghcr.io/zephyrproject-rtos/ci:v0.24.6 # zephyr:main (current)
-docker pull ghcr.io/zephyrproject-rtos/ci:v0.24.5 # zephyr:main (prev)
+docker pull ghcr.io/zephyrproject-rtos/ci:v0.24.11 # zephyr:main (current)
+docker pull ghcr.io/zephyrproject-rtos/ci:v0.24.6 # zephyr:main (prev)
 docker pull ghcr.io/zephyrproject-rtos/ci:v0.24.2 # zephyr:v3.2-branch
 docker pull ghcr.io/zephyrproject-rtos/ci:v0.23.3 # zephyr:v3.1-branch
 docker pull zephyrprojectrtos/ci:v0.21.0 # zephyr:v3.0-branch
@@ -28,7 +28,7 @@ mkdir -p /pod-cache/repos
 mkdir -p /pod-cache/tools
 
 # Clone Zephyr repositories
-docker run -i --network host -v /pod-cache:/pod-cache ghcr.io/zephyrproject-rtos/ci:v0.24.5 <<-EOF
+docker run -i --network host -v /pod-cache:/pod-cache ghcr.io/zephyrproject-rtos/ci:v0.24.11 <<-EOF
 su user
 mkdir -p /pod-cache/repos/zephyrproject
 cd /pod-cache/repos/zephyrproject

--- a/terraform/zephyr-aws-blueprints/main.tf
+++ b/terraform/zephyr-aws-blueprints/main.tf
@@ -47,7 +47,7 @@ data "aws_ami" "zephyr_runner_node_x86_64" {
 
   filter {
     name   = "name"
-    values = ["zephyr-runner-node-x86_64-1669225251"]
+    values = ["zephyr-runner-node-x86_64-1676379163"]
   }
 
   owners = ["724087766192"]
@@ -58,7 +58,7 @@ data "aws_ami" "zephyr_runner_node_arm64" {
 
   filter {
     name   = "name"
-    values = ["zephyr-runner-node-arm64-1669228883"]
+    values = ["zephyr-runner-node-arm64-1676381580"]
   }
 
   owners = ["724087766192"]


### PR DESCRIPTION
This commit updates the AMI to cache the CI docker image v0.24.11 used
by the main branch.
