### PR TITLE
ci: Add zephyr-runner-node Packer image build workflow

### DIFF
--- a/.github/workflows/packer.yaml
+++ b/.github/workflows/packer.yaml
@@ -1,0 +1,53 @@
+name: Packer (zephyr-runner-node)
+
+on:
+  push:
+    branches:
+    - main
+    paths:
+    - '.github/workflows/packer.yaml'
+    - 'packer/zephyr-runner-node/**'
+  pull_request:
+    branches:
+    - main
+    paths:
+    - '.github/workflows/packer.yaml'
+    - 'packer/zephyr-runner-node/**'
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-22.04
+
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v3
+
+    - name: Set up Packer
+      uses: hashicorp/setup-packer@v2.0.0
+      with:
+        version: latest
+
+    - name: Initialise Packer
+      run: |
+        cd packer/zephyr-runner-node
+        packer init zephyr-runner-node-arm64.pkr.hcl
+        packer init zephyr-runner-node-x86_64.pkr.hcl
+
+    - name: Validate Packer script
+      run: |
+        cd packer/zephyr-runner-node
+        packer validate zephyr-runner-node-arm64.pkr.hcl
+        packer validate zephyr-runner-node-x86_64.pkr.hcl
+
+    - name: Build image from Packer script
+      if: github.event_name == 'push'
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_MAX_ATTEMPTS: 120
+        AWS_POLL_DELAY_SECONDS: 60
+      run: |
+        cd packer/zephyr-runner-node
+        packer build zephyr-runner-node-arm64.pkr.hcl
+        packer build zephyr-runner-node-x86_64.pkr.hcl


### PR DESCRIPTION
This commit adds a new GitHub Actions workflow to build the zephyr-runner-node image using Packer.