### PR TITLE
ci: Add zephyr-runner-node Packer image build workflow

### DIFF
--- a/.github/workflows/packer_zephyr-runner-node.yaml
+++ b/.github/workflows/packer_zephyr-runner-node.yaml
@@ -1,0 +1,61 @@
+name: Packer (zephyr-runner-node)
+
+on:
+  push:
+    branches:
+    - main
+    paths:
+    - '.github/workflows/packer.yaml'
+    - 'packer/zephyr-runner-node/**'
+  pull_request:
+    branches:
+    - main
+    paths:
+    - '.github/workflows/packer.yaml'
+    - 'packer/zephyr-runner-node/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build (${{ matrix.image }})
+    runs-on: ubuntu-22.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+        - zephyr-runner-node-arm64
+        - zephyr-runner-node-x86_64
+
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v3
+
+    - name: Set up Packer
+      uses: hashicorp/setup-packer@v2.0.0
+      with:
+        version: latest
+
+    - name: Initialise Packer
+      run: |
+        cd packer/zephyr-runner-node
+        packer init ${{ matrix.image }}.pkr.hcl
+
+    - name: Validate Packer script
+      run: |
+        cd packer/zephyr-runner-node
+        packer validate ${{ matrix.image }}.pkr.hcl
+
+    - name: Build image from Packer script
+      if: github.event_name == 'push'
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_MAX_ATTEMPTS: 120
+        AWS_POLL_DELAY_SECONDS: 60
+      run: |
+        cd packer/zephyr-runner-node
+        packer build ${{ matrix.image }}.pkr.hcl


### PR DESCRIPTION
This commit adds a new GitHub Actions workflow to build the zephyr-runner-node image using Packer.