### PR TITLE
zephyr-runner-node: Add CI Docker image v0.25.1

### DIFF
--- a/packer/zephyr-runner-node/script.sh
+++ b/packer/zephyr-runner-node/script.sh
@@ -13,11 +13,10 @@ sudo cp -R /var/lib/docker /var/lib/docker-orig
 sudo systemctl start docker
 
 # Cache CI Docker images
-docker pull ghcr.io/zephyrproject-rtos/ci:v0.25.0 # zephyr:main (current)
-docker pull ghcr.io/zephyrproject-rtos/ci:v0.24.11 # zephyr:main (prev)
+docker pull ghcr.io/zephyrproject-rtos/ci:v0.25.1 # zephyr:main (current)
+docker pull ghcr.io/zephyrproject-rtos/ci:v0.25.0 # zephyr:main (prev)
+docker pull ghcr.io/zephyrproject-rtos/ci:v0.24.11 # zephyr:v3.3-branch
 docker pull ghcr.io/zephyrproject-rtos/ci:v0.24.2 # zephyr:v3.2-branch
-docker pull ghcr.io/zephyrproject-rtos/ci:v0.23.3 # zephyr:v3.1-branch
-docker pull zephyrprojectrtos/ci:v0.21.0 # zephyr:v3.0-branch
 docker pull zephyrprojectrtos/ci:v0.18.4 # zephyr:v2.7-branch
 docker pull ghcr.io/zephyrproject-rtos/sdk-build:v1.2.3 # sdk-ng:main
 
@@ -28,7 +27,7 @@ mkdir -p /pod-cache/repos
 mkdir -p /pod-cache/tools
 
 # Clone Zephyr repositories
-docker run -i --network host -v /pod-cache:/pod-cache ghcr.io/zephyrproject-rtos/ci:v0.24.11 <<-EOF
+docker run -i --network host -v /pod-cache:/pod-cache ghcr.io/zephyrproject-rtos/ci:v0.25.1 <<-EOF
 su user
 mkdir -p /pod-cache/repos/zephyrproject
 cd /pod-cache/repos/zephyrproject


### PR DESCRIPTION
This commit updates the AMI to cache the CI docker image v0.25.1 used by the main branch.