### PR TITLE
zephyr-aws-blueprints: Use zephyr-runner AMI 2023-04-28

### DIFF
--- a/terraform/zephyr-aws-blueprints/main.tf
+++ b/terraform/zephyr-aws-blueprints/main.tf
@@ -47,7 +47,7 @@ data "aws_ami" "zephyr_runner_node_x86_64" {
 
   filter {
     name   = "name"
-    values = ["zephyr-runner-node-x86_64-1681393197"]
+    values = ["zephyr-runner-node-x86_64-1682612410"]
   }
 
   owners = ["724087766192"]
@@ -58,7 +58,7 @@ data "aws_ami" "zephyr_runner_node_arm64" {
 
   filter {
     name   = "name"
-    values = ["zephyr-runner-node-arm64-1681393193"]
+    values = ["zephyr-runner-node-arm64-1682612407"]
   }
 
   owners = ["724087766192"]


### PR DESCRIPTION
This commit updates the zephyr-runner deployment to use the AMI 2023-04-28, which includes the CI docker image v0.26.2 and v0.24.3.