### PR TITLE
zephyr-aws-blueprints: Use c6gn.4xlarge for linux-arm64-4xlarge

### DIFF
--- a/terraform/zephyr-aws-blueprints/main.tf
+++ b/terraform/zephyr-aws-blueprints/main.tf
@@ -365,7 +365,7 @@ module "eks_blueprints" {
       ami_type        = "CUSTOM"
       custom_ami_id   = data.aws_ami.zephyr_runner_node_arm64.id
       capacity_type   = "SPOT"
-      instance_types  = ["c6g.4xlarge"] # "c7g.4xlarge", "c6gn.4xlarge"
+      instance_types  = ["c6gn.4xlarge"] # "c6g.4xlarge", "c7g.4xlarge", "c7gn.4xlarge"
 
       # Node Group network configuration
       subnet_type = "private" # public or private - Default uses the private subnets used in control plane if you don't pass the "subnet_ids"


### PR DESCRIPTION
This commit updates `linux-arm64-4xlarge` node group to use the `c6gn.4xlarge` instance type because the current instance type, `c6g.4xlarge` has a very high interruption rate and is unsuitable for building Zephyr SDK.