### PR TITLE
packer: aws-zephyr-runner-node: Cache actions-runner 2.311.0

### DIFF
--- a/packer/aws-zephyr-runner-node/aws-zephyr-runner-node-arm64.pkr.hcl
+++ b/packer/aws-zephyr-runner-node/aws-zephyr-runner-node-arm64.pkr.hcl
@@ -15,7 +15,7 @@ source "amazon-ebs" "zephyr_runner_node_arm64" {
   ssh_username  = "ec2-user"
   launch_block_device_mappings {
     device_name = "/dev/xvda"
-    volume_size = 80
+    volume_size = 120
     volume_type = "gp3"
     iops        = 3000
     throughput  = 125

--- a/packer/aws-zephyr-runner-node/aws-zephyr-runner-node-x86_64.pkr.hcl
+++ b/packer/aws-zephyr-runner-node/aws-zephyr-runner-node-x86_64.pkr.hcl
@@ -15,7 +15,7 @@ source "amazon-ebs" "zephyr_runner_node_x86_64" {
   ssh_username  = "ec2-user"
   launch_block_device_mappings {
     device_name = "/dev/xvda"
-    volume_size = 80
+    volume_size = 120
     volume_type = "gp3"
     iops        = 3000
     throughput  = 125

--- a/packer/aws-zephyr-runner-node/script.sh
+++ b/packer/aws-zephyr-runner-node/script.sh
@@ -8,7 +8,7 @@ set -eux
 sudo systemctl start docker
 
 ## Docker images for Actions Runner Controller
-docker pull ghcr.io/actions-runner-controller/actions-runner-controller/actions-runner:latest
+docker pull ghcr.io/actions/actions-runner:2.311.0
 
 ## Docker images for zephyr repository CI workflows
 docker pull ghcr.io/zephyrproject-rtos/ci-repo-cache:v0.26.6.20231213 # zephyr:main (current)


### PR DESCRIPTION
This commit updates the aws-zephyr-runner-node AMI build script to cache the actions-runner Docker image 2.311.0, which is used by the zephyr-runner v2 deployment.