### PR TITLE
aws-zephyr-runner-v1-node: Add CI Docker image v0.26.7

### DIFF
--- a/.github/workflows/packer_aws-zephyr-runner-v1-node.yaml
+++ b/.github/workflows/packer_aws-zephyr-runner-v1-node.yaml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         image:
-        - aws-zephyr-runner-v1-node-arm64
+        # - aws-zephyr-runner-v1-node-arm64
         - aws-zephyr-runner-v1-node-x86_64
 
     steps:

--- a/packer/aws-zephyr-runner-v1-node/script.sh
+++ b/packer/aws-zephyr-runner-v1-node/script.sh
@@ -13,10 +13,10 @@ sudo cp -R /var/lib/docker /var/lib/docker-orig
 sudo systemctl start docker
 
 # Cache CI Docker images
-docker pull ghcr.io/zephyrproject-rtos/ci:v0.26.6 # zephyr:main (current)
-docker pull ghcr.io/zephyrproject-rtos/ci:v0.26.5 # zephyr:main (prev)
+docker pull ghcr.io/zephyrproject-rtos/ci:v0.26.7 # zephyr:main (current)
+docker pull ghcr.io/zephyrproject-rtos/ci:v0.26.6 # zephyr:main (prev)
+docker pull ghcr.io/zephyrproject-rtos/ci:v0.26.5 # zephyr:v3.5-branch
 docker pull ghcr.io/zephyrproject-rtos/ci:v0.26.4 # zephyr:v3.4-branch
-docker pull ghcr.io/zephyrproject-rtos/ci:v0.24.11 # zephyr:v3.3-branch
 docker pull zephyrprojectrtos/ci:v0.18.4 # zephyr:v2.7-branch
 docker pull ghcr.io/zephyrproject-rtos/sdk-build:v1.2.3 # sdk-ng:main
 
@@ -27,7 +27,7 @@ mkdir -p /pod-cache/repos
 mkdir -p /pod-cache/tools
 
 # Clone Zephyr repositories
-docker run -i --network host -v /pod-cache:/pod-cache ghcr.io/zephyrproject-rtos/ci:v0.26.6 <<-EOF
+docker run -i --network host -v /pod-cache:/pod-cache ghcr.io/zephyrproject-rtos/ci:v0.26.7 <<-EOF
 su user
 mkdir -p /pod-cache/repos/zephyrproject
 cd /pod-cache/repos/zephyrproject


### PR DESCRIPTION
This commit updates the AMI to cache the CI Docker image v0.26.7 used by the main branch.

In addition, it also updates the AMI ot cache the CI Docker image for the v3.5 release branch.