### PR TITLE
zephyr-aws-blueprints: Use zephyr-runner AMI 2024-02-04

### DIFF
--- a/terraform/zephyr-aws-blueprints/main.tf
+++ b/terraform/zephyr-aws-blueprints/main.tf
@@ -47,7 +47,7 @@ data "aws_ami" "zephyr_runner_node_x86_64" {
 
   filter {
     name   = "name"
-    values = ["zephyr-runner-node-x86_64-1700673478"]
+    values = ["zephyr-runner-node-x86_64-1707039002"]
   }
 
   owners = ["724087766192"]


### PR DESCRIPTION
This commit updates the zephyr-runner deployment to use the AMI 2024-02-04, which includes the CI Docker image v0.26.7.

Note that this only updates the x86-64 AMI because the AArch64 AMI is not built due to the missing Zephyr SDK release for the architecture.

Also note that this uses the AMI for zephyr-runner v1 because v2 is still work-in-progress.