### PR TITLE
terraform: Add cnx-zephyr-test cluster manifests

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -20,3 +20,9 @@ configuration files for the Zephyr infrastructure components.
     * Staging Kubernetes cluster for Zephyr infrastructure services.
     * Hosted on Amazon Web Services.
     * Terraform plan and applies are locally executed with Terraform Cloud state backend.
+
+* cnx-zephyr-test
+
+    * Staging Kubernetes cluster for Zephyr infrastructure services.
+    * Hosted on Centrinix Cloud.
+    * Terraform plan and applies are locally executed with Terraform Cloud state backend.

--- a/terraform/cnx-zephyr-test/.terraform.lock.hcl
+++ b/terraform/cnx-zephyr-test/.terraform.lock.hcl
@@ -1,0 +1,60 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/gavinbunney/kubectl" {
+  version     = "1.14.0"
+  constraints = ">= 1.14.0"
+  hashes = [
+    "h1:gLFn+RvP37sVzp9qnFCwngRjjFV649r6apjxvJ1E/SE=",
+    "zh:0350f3122ff711984bbc36f6093c1fe19043173fad5a904bce27f86afe3cc858",
+    "zh:07ca36c7aa7533e8325b38232c77c04d6ef1081cb0bac9d56e8ccd51f12f2030",
+    "zh:0c351afd91d9e994a71fe64bbd1662d0024006b3493bb61d46c23ea3e42a7cf5",
+    "zh:39f1a0aa1d589a7e815b62b5aa11041040903b061672c4cfc7de38622866cbc4",
+    "zh:428d3a321043b78e23c91a8d641f2d08d6b97f74c195c654f04d2c455e017de5",
+    "zh:4baf5b1de2dfe9968cc0f57fd4be5a741deb5b34ee0989519267697af5f3eee5",
+    "zh:6131a927f9dffa014ab5ca5364ac965fe9b19830d2bbf916a5b2865b956fdfcf",
+    "zh:c62e0c9fd052cbf68c5c2612af4f6408c61c7e37b615dc347918d2442dd05e93",
+    "zh:f0beffd7ce78f49ead612e4b1aefb7cb6a461d040428f514f4f9cc4e5698ac65",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version = "2.25.2"
+  hashes = [
+    "h1:QlTKoO0efmkzgX/9y0DQCEkg7VeidOSQW8epF6B4cEQ=",
+    "zh:044788ac936e0e8ece8f78a2e4e366ecd435ea8235388eaf2cbc8e7975d9d970",
+    "zh:24f5ff01df91f51f00ee7ff39430adeb63bb2ca4ea0042e68f06d6b65808c02f",
+    "zh:49984aa0aa1faa8c4f01e8faa039322f1e6fdaeab0b7e32f5c6e96edfde36a38",
+    "zh:4eeceaff56bac9fc782e7e33f157fa2c7e9a47b2c3c3d12da2642c312ace73f6",
+    "zh:4f49b6419345960d5af475e0200c243af4c9c140b0ee64799fe1fc9b023c49ea",
+    "zh:7958414d516867a2263a978792a24843f80023fb233cf051ff4095adc9803d85",
+    "zh:c633a755fc95e9ff0cd73656f052947afd85883a0987dde5198113aa48474156",
+    "zh:cbfe958d119795004ce1e8001449d01c056fa2a062b51d07843d98be216337d7",
+    "zh:cfb85392e18768578d4c943438897083895719be678227fd90efbe3500702a56",
+    "zh:d705a661ed5da425dd236a48645bec39fe78a67d2e70e8460b720417cbf260ac",
+    "zh:ddd7a01263da3793df4f3b5af65f166307eed5acf525e51e058cda59009cc856",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/terraform-provider-openstack/openstack" {
+  version     = "1.53.0"
+  constraints = "1.53.0"
+  hashes = [
+    "h1:YLGvYkSuagyP5orUTyKNK+JhzS17EFTUDpZ5R5/fFv4=",
+    "zh:09da7ca98ffd3de7b9ce36c4c13446212a6e763ba1162be71b50f95d453cb68e",
+    "zh:14041bcbb87312411d88612056ed185650bfd01284b8ea0761ce8105a331708e",
+    "zh:35bf4c788fdbc17c8e40ebc7b33c7de4b45a2fa2efaa657b10f0e3bd37c9627f",
+    "zh:46ede8ef4cfa12d654c538afc1e1ec34a1f3e8eb4e986ee23dceae398b7176a6",
+    "zh:59675734990dab1e8d87997853ea75e8104bba730b3f5a7146ac735540c9d6bf",
+    "zh:6de52428849806498670e827b54810be7510a2a79449602c1aede4235a0ec036",
+    "zh:78b2a20601272afceffac8f8ca78a6b647b84196c0dd8dc710fae297f6be15a4",
+    "zh:7c41ed3a4fac09677e676ecf9f9edd1e38eef449e656cb01a848d2c799c6de8f",
+    "zh:852800228f4118a4aa6cfaa4468b851247cbed6f037fd204f08de69eb1edc149",
+    "zh:86d618e7f9a07d978b8bc4b190be350a00de64ec535f9c8f5dfe133542a55483",
+    "zh:963a9e72b66d8bcf43de9b14a674ae3ca3719ce2f829217f7a65b66fc3773397",
+    "zh:a8e72ab67795071bda61f99a6de3d2d40122fb51971768fd75e1324abe874ced",
+    "zh:ce1890cf3af17d569af3bc7673cec0a8f78e6f5d701767593f3d29c551f44848",
+    "zh:e6f1b96eb684f527a47f71923f268c86a36d7894751b31ee9e726d7502a639cd",
+  ]
+}

--- a/terraform/cnx-zephyr-test/README.md
+++ b/terraform/cnx-zephyr-test/README.md
@@ -1,0 +1,58 @@
+# cnx-zephyr-test
+
+## Overview
+
+This directory contains the Terraform manifests that define the resources for
+the test Kubernetes cluster in the Centrinix Cloud.
+
+The resources defined here are deployed to the `test` project of the
+`zephyrproject` domain in the [Centrinix OpenStack
+cloud](https://openstack.centrinix.cloud).
+
+## Deployment
+
+### Overview
+
+Deployment process must be executed locally using the Terraform cloud state
+backend, which is managed in the `cnx-zephyr-test` workspace in the Terraform
+cloud.
+
+### Host Requirements
+
+The deployment host must have Terraform, OpenStack Client
+(`python-openstackclient`) and kubectl installed.
+
+In addition, the deployment host must have access to the Centrinix Cloud CGN
+(carrier grade NAT) network, which requires a special VPN connection, for
+connecting to the Kubernetes cluster endpoints.
+
+### Initial Deployment
+
+It is recommended to execute the cluster deployment process in multiple partial
+steps to ensure that each component layer is fully deployed before proceeding to
+deploy the next layer.
+
+1. Deploy cluster template:
+
+```
+terraform apply -target=openstack_containerinfra_clustertemplate_v1.kubernetes_1_23_zephyr_test1
+```
+
+2. Deploy Kubernetes cluster:
+
+```
+terraform apply -target=openstack_containerinfra_cluster_v1.zephyr_test1
+```
+
+3. Deploy node groups:
+
+```
+terraform apply -target=openstack_containerinfra_nodegroup_v1.az3_linux_arm64
+terraform apply -target=openstack_containerinfra_nodegroup_v1.az3_linux_x64
+```
+
+4. Deploy rest of the resources:
+
+```
+terraform apply
+```

--- a/terraform/cnx-zephyr-test/main.tf
+++ b/terraform/cnx-zephyr-test/main.tf
@@ -1,0 +1,115 @@
+# Providers
+provider "openstack" {
+  region      = "Gumi"
+  domain_name = "zephyrproject"
+  tenant_name = "test"
+}
+
+provider "kubernetes" {
+  host                   = openstack_containerinfra_cluster_v1.zephyr_test1.kubeconfig.host
+  cluster_ca_certificate = openstack_containerinfra_cluster_v1.zephyr_test1.kubeconfig.cluster_ca_certificate
+  client_certificate     = openstack_containerinfra_cluster_v1.zephyr_test1.kubeconfig.client_certificate
+  client_key             = openstack_containerinfra_cluster_v1.zephyr_test1.kubeconfig.client_key
+}
+
+provider "kubectl" {
+  host                   = openstack_containerinfra_cluster_v1.zephyr_test1.kubeconfig.host
+  cluster_ca_certificate = openstack_containerinfra_cluster_v1.zephyr_test1.kubeconfig.cluster_ca_certificate
+  client_certificate     = openstack_containerinfra_cluster_v1.zephyr_test1.kubeconfig.client_certificate
+  client_key             = openstack_containerinfra_cluster_v1.zephyr_test1.kubeconfig.client_key
+  load_config_file       = false
+}
+
+# kubernetes-1.23-zephyr-test1 Magnum Kubernetes Cluster Template
+resource "openstack_containerinfra_clustertemplate_v1" "kubernetes_1_23_zephyr_test1" {
+  name                  = "kubernetes-1.23-zephyr-test1"
+  image                 = "fedora-coreos-35.20220116.3.0-x86_64"
+  coe                   = "kubernetes"
+  server_type           = "vm"
+  master_flavor         = "m1.2xlarge"
+  flavor                = "m1.4xlarge"
+  volume_driver         = "cinder"
+  docker_storage_driver = "overlay2"
+  docker_volume_size    = 100
+  network_driver        = "flannel"
+  floating_ip_enabled   = true
+  master_lb_enabled     = false
+  external_network_id   = "28cf8e6a-bb4f-4ff2-8c1b-f018fd4e792f"
+  dns_nameserver        = "100.64.1.1"
+
+  labels = {
+    container_infra_prefix           = "registry.centrinix.cloud/openstack/"
+    node_problem_detector_tag        = "v0.8.15"
+    selinux_mode                     = "permissive"
+    boot_volume_size                 = "20"
+    boot_volume_type                 = "fc_r1"
+    docker_volume_type               = "fc_r1"
+  }
+}
+
+# zephyr-test1 Magnum Kubernetes Cluster
+resource "openstack_containerinfra_cluster_v1" "zephyr_test1" {
+  name                = "zephyr-test1"
+  cluster_template_id = openstack_containerinfra_clustertemplate_v1.kubernetes_1_23_zephyr_test1.id
+  floating_ip_enabled = true
+  master_count        = 1
+  node_count          = 1
+  keypair             = "test2"
+  merge_labels        = true
+
+  labels = {
+    availability_zone    = "az1"
+    auto_scaling_enabled = "False"
+    auto_healing_enabled = "False"
+  }
+
+  depends_on          = [openstack_containerinfra_clustertemplate_v1.kubernetes_1_23_zephyr_test1]
+}
+
+# az3-linux-arm64 Node Group
+resource "openstack_containerinfra_nodegroup_v1" "az3_linux_arm64" {
+  name                = "az3-linux-arm64"
+  cluster_id          = openstack_containerinfra_cluster_v1.zephyr_test1.id
+  image_id            = "fedora-coreos-35.20220116.3.0-aarch64"
+  flavor_id           = "m1a.4xlarge"
+  docker_volume_size  = 100
+  role                = "worker"
+  node_count          = 1
+  merge_labels        = true
+
+  labels = {
+    availability_zone = "az3"
+  }
+
+  depends_on          = [openstack_containerinfra_cluster_v1.zephyr_test1]
+}
+
+# az3-linux-x64 Node Group
+resource "openstack_containerinfra_nodegroup_v1" "az3_linux_x64" {
+  name                = "az3-linux-x64"
+  cluster_id          = openstack_containerinfra_cluster_v1.zephyr_test1.id
+  image_id            = "fedora-coreos-35.20220116.3.0-x86_64"
+  flavor_id           = "m1.4xlarge"
+  docker_volume_size  = 100
+  role                = "worker"
+  node_count          = 1
+  merge_labels        = true
+
+  labels = {
+    availability_zone = "az3"
+  }
+
+  depends_on          = [openstack_containerinfra_cluster_v1.zephyr_test1]
+}
+
+# cnx-privileged Pod Security Policy
+data "kubectl_path_documents" "cnx_privileged_manifests" {
+  pattern = "../../kubernetes/zephyr-runner-v2/cnx/cnx-privileged/privileged-podsecuritypolicy.yaml"
+}
+
+resource "kubectl_manifest" "cnx_privileged_manifest" {
+  count      = length(data.kubectl_path_documents.cnx_privileged_manifests.documents)
+  yaml_body  = element(data.kubectl_path_documents.cnx_privileged_manifests.documents, count.index)
+  wait       = true
+  depends_on = [openstack_containerinfra_cluster_v1.zephyr_test1]
+}

--- a/terraform/cnx-zephyr-test/terraform-cloud.tf
+++ b/terraform/cnx-zephyr-test/terraform-cloud.tf
@@ -1,0 +1,8 @@
+terraform {
+  cloud {
+    organization = "zephyrproject-rtos"
+    workspaces {
+      name = "cnx-zephyr-test"
+    }
+  }
+}

--- a/terraform/cnx-zephyr-test/versions.tf
+++ b/terraform/cnx-zephyr-test/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 0.14.0"
+
+  required_providers {
+    openstack = {
+      source  = "terraform-provider-openstack/openstack"
+      version = "1.53.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.10"
+    }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = ">= 1.14"
+    }
+  }
+}


### PR DESCRIPTION
This commit adds the Terraform manifests for the staging/test Kubernetes cluster deployment in the Centrinix Cloud.