### PR TITLE
zephyr-runner-v2: Increase ACTIONS_RUNNER_PREPARE_JOB_TIMEOUT_SECONDS

### DIFF
--- a/kubernetes/zephyr-runner-v2/aws/test-runner-scale-sets/test-runner-v2-linux-arm64-4xlarge-aws/values.yaml
+++ b/kubernetes/zephyr-runner-v2/aws/test-runner-scale-sets/test-runner-v2-linux-arm64-4xlarge-aws/values.yaml
@@ -41,6 +41,9 @@ template:
       # Allow running workflow jobs outside a container.
       - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
         value: "false"
+      # Set container image download timeout to 1 hour.
+      - name: ACTIONS_RUNNER_PREPARE_JOB_TIMEOUT_SECONDS
+        value: "3600"
       # Use custom workflow pod template.
       - name: ACTIONS_RUNNER_CONTAINER_HOOK_TEMPLATE
         value: /home/runner/pod-templates/workflow.yaml

--- a/kubernetes/zephyr-runner-v2/aws/test-runner-scale-sets/test-runner-v2-linux-x64-4xlarge-aws/values.yaml
+++ b/kubernetes/zephyr-runner-v2/aws/test-runner-scale-sets/test-runner-v2-linux-x64-4xlarge-aws/values.yaml
@@ -41,6 +41,9 @@ template:
       # Allow running workflow jobs outside a container.
       - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
         value: "false"
+      # Set container image download timeout to 1 hour.
+      - name: ACTIONS_RUNNER_PREPARE_JOB_TIMEOUT_SECONDS
+        value: "3600"
       # Use custom workflow pod template.
       - name: ACTIONS_RUNNER_CONTAINER_HOOK_TEMPLATE
         value: /home/runner/pod-templates/workflow.yaml

--- a/kubernetes/zephyr-runner-v2/aws/zephyr-runner-scale-sets/zephyr-runner-v2-linux-x64-4xlarge-aws/values.yaml
+++ b/kubernetes/zephyr-runner-v2/aws/zephyr-runner-scale-sets/zephyr-runner-v2-linux-x64-4xlarge-aws/values.yaml
@@ -41,6 +41,9 @@ template:
       # Allow running workflow jobs outside a container.
       - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
         value: "false"
+      # Set container image download timeout to 1 hour.
+      - name: ACTIONS_RUNNER_PREPARE_JOB_TIMEOUT_SECONDS
+        value: "3600"
       # Use custom workflow pod template.
       - name: ACTIONS_RUNNER_CONTAINER_HOOK_TEMPLATE
         value: /home/runner/pod-templates/workflow.yaml

--- a/kubernetes/zephyr-runner-v2/cnx/test-runner-scale-sets/test-runner-v2-linux-arm64-4xlarge-cnx/values.yaml
+++ b/kubernetes/zephyr-runner-v2/cnx/test-runner-scale-sets/test-runner-v2-linux-arm64-4xlarge-cnx/values.yaml
@@ -41,6 +41,9 @@ template:
       # Allow running workflow jobs outside a container.
       - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
         value: "false"
+      # Set container image download timeout to 1 hour.
+      - name: ACTIONS_RUNNER_PREPARE_JOB_TIMEOUT_SECONDS
+        value: "3600"
       # Use custom workflow pod template.
       - name: ACTIONS_RUNNER_CONTAINER_HOOK_TEMPLATE
         value: /home/runner/pod-templates/workflow.yaml

--- a/kubernetes/zephyr-runner-v2/cnx/test-runner-scale-sets/test-runner-v2-linux-x64-4xlarge-cnx/values.yaml
+++ b/kubernetes/zephyr-runner-v2/cnx/test-runner-scale-sets/test-runner-v2-linux-x64-4xlarge-cnx/values.yaml
@@ -41,6 +41,9 @@ template:
       # Allow running workflow jobs outside a container.
       - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
         value: "false"
+      # Set container image download timeout to 1 hour.
+      - name: ACTIONS_RUNNER_PREPARE_JOB_TIMEOUT_SECONDS
+        value: "3600"
       # Use custom workflow pod template.
       - name: ACTIONS_RUNNER_CONTAINER_HOOK_TEMPLATE
         value: /home/runner/pod-templates/workflow.yaml

--- a/kubernetes/zephyr-runner-v2/cnx/zephyr-runner-scale-sets/zephyr-runner-v2-linux-arm64-4xlarge-cnx/values.yaml
+++ b/kubernetes/zephyr-runner-v2/cnx/zephyr-runner-scale-sets/zephyr-runner-v2-linux-arm64-4xlarge-cnx/values.yaml
@@ -41,6 +41,9 @@ template:
       # Allow running workflow jobs outside a container.
       - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
         value: "false"
+      # Set container image download timeout to 1 hour.
+      - name: ACTIONS_RUNNER_PREPARE_JOB_TIMEOUT_SECONDS
+        value: "3600"
       # Use custom workflow pod template.
       - name: ACTIONS_RUNNER_CONTAINER_HOOK_TEMPLATE
         value: /home/runner/pod-templates/workflow.yaml

--- a/kubernetes/zephyr-runner-v2/cnx/zephyr-runner-scale-sets/zephyr-runner-v2-linux-x64-4xlarge-cnx/values.yaml
+++ b/kubernetes/zephyr-runner-v2/cnx/zephyr-runner-scale-sets/zephyr-runner-v2-linux-x64-4xlarge-cnx/values.yaml
@@ -41,6 +41,9 @@ template:
       # Allow running workflow jobs outside a container.
       - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
         value: "false"
+      # Set container image download timeout to 1 hour.
+      - name: ACTIONS_RUNNER_PREPARE_JOB_TIMEOUT_SECONDS
+        value: "3600"
       # Use custom workflow pod template.
       - name: ACTIONS_RUNNER_CONTAINER_HOOK_TEMPLATE
         value: /home/runner/pod-templates/workflow.yaml


### PR DESCRIPTION
This commit increases the ACTIONS_RUNNER_PREPARE_JOB_TIMEOUT_SECONDS from the default value of 600 seconds to 3600 seconds because the CI Docker images are very large and pulling them for the first time can take a long time.

Note that the CI Docker images are not cached in the Centrinix deployment because the runner nodes are non-ephemeral and therefore only need to download the CI Docker images once after provisioning.