### PR TITLE
zephyr-runner-v2: cnx: Add node cache

### DIFF
--- a/kubernetes/zephyr-runner-v2/cnx/test-runner-scale-sets/test-runner-v2-linux-arm64-4xlarge-cnx/values.yaml
+++ b/kubernetes/zephyr-runner-v2/cnx/test-runner-scale-sets/test-runner-v2-linux-arm64-4xlarge-cnx/values.yaml
@@ -62,6 +62,8 @@ template:
       - name: pod-templates
         mountPath: /home/runner/pod-templates
         readOnly: true
+      - name: node-cache
+        mountPath: /node-cache
       # CPU and RAM allocations
       resources:
         limits:
@@ -74,6 +76,10 @@ template:
     - name: pod-templates
       configMap:
         name: test-runner-v2-pod-templates
+    - name: node-cache
+      hostPath:
+        path: /var/lib/docker/zephyr-runner-v2/node-cache
+        type: DirectoryOrCreate
     nodeSelector:
       kubernetes.io/os: linux
       kubernetes.io/arch: arm64

--- a/kubernetes/zephyr-runner-v2/cnx/test-runner-scale-sets/test-runner-v2-linux-x64-4xlarge-cnx/values.yaml
+++ b/kubernetes/zephyr-runner-v2/cnx/test-runner-scale-sets/test-runner-v2-linux-x64-4xlarge-cnx/values.yaml
@@ -62,6 +62,8 @@ template:
       - name: pod-templates
         mountPath: /home/runner/pod-templates
         readOnly: true
+      - name: node-cache
+        mountPath: /node-cache
       # CPU and RAM allocations
       resources:
         limits:
@@ -74,6 +76,10 @@ template:
     - name: pod-templates
       configMap:
         name: test-runner-v2-pod-templates
+    - name: node-cache
+      hostPath:
+        path: /var/lib/docker/zephyr-runner-v2/node-cache
+        type: DirectoryOrCreate
     nodeSelector:
       kubernetes.io/os: linux
       kubernetes.io/arch: amd64

--- a/kubernetes/zephyr-runner-v2/cnx/test-runner-scale-sets/test-runner-v2-pod-templates.yaml
+++ b/kubernetes/zephyr-runner-v2/cnx/test-runner-scale-sets/test-runner-v2-pod-templates.yaml
@@ -27,3 +27,11 @@ data:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        volumeMounts:
+        - name: node-cache
+          mountPath: /node-cache
+      volumes:
+      - name: node-cache
+        hostPath:
+          path: /var/lib/docker/zephyr-runner-v2/node-cache
+          type: DirectoryOrCreate

--- a/kubernetes/zephyr-runner-v2/cnx/zephyr-runner-scale-sets/zephyr-runner-v2-linux-arm64-4xlarge-cnx/values.yaml
+++ b/kubernetes/zephyr-runner-v2/cnx/zephyr-runner-scale-sets/zephyr-runner-v2-linux-arm64-4xlarge-cnx/values.yaml
@@ -62,6 +62,8 @@ template:
       - name: pod-templates
         mountPath: /home/runner/pod-templates
         readOnly: true
+      - name: node-cache
+        mountPath: /node-cache
       # CPU and RAM allocations
       resources:
         limits:
@@ -74,6 +76,10 @@ template:
     - name: pod-templates
       configMap:
         name: zephyr-runner-v2-pod-templates
+    - name: node-cache
+      hostPath:
+        path: /var/lib/docker/zephyr-runner-v2/node-cache
+        type: DirectoryOrCreate
     nodeSelector:
       kubernetes.io/os: linux
       kubernetes.io/arch: arm64

--- a/kubernetes/zephyr-runner-v2/cnx/zephyr-runner-scale-sets/zephyr-runner-v2-linux-x64-4xlarge-cnx/values.yaml
+++ b/kubernetes/zephyr-runner-v2/cnx/zephyr-runner-scale-sets/zephyr-runner-v2-linux-x64-4xlarge-cnx/values.yaml
@@ -62,6 +62,8 @@ template:
       - name: pod-templates
         mountPath: /home/runner/pod-templates
         readOnly: true
+      - name: node-cache
+        mountPath: /node-cache
       # CPU and RAM allocations
       resources:
         limits:
@@ -74,6 +76,10 @@ template:
     - name: pod-templates
       configMap:
         name: zephyr-runner-v2-pod-templates
+    - name: node-cache
+      hostPath:
+        path: /var/lib/docker/zephyr-runner-v2/node-cache
+        type: DirectoryOrCreate
     nodeSelector:
       kubernetes.io/os: linux
       kubernetes.io/arch: amd64

--- a/kubernetes/zephyr-runner-v2/cnx/zephyr-runner-scale-sets/zephyr-runner-v2-pod-templates.yaml
+++ b/kubernetes/zephyr-runner-v2/cnx/zephyr-runner-scale-sets/zephyr-runner-v2-pod-templates.yaml
@@ -27,3 +27,11 @@ data:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        volumeMounts:
+        - name: node-cache
+          mountPath: /node-cache
+      volumes:
+      - name: node-cache
+        hostPath:
+          path: /var/lib/docker/zephyr-runner-v2/node-cache
+          type: DirectoryOrCreate


### PR DESCRIPTION
This commit adds a hostPath mount to the "node cache" directory on the runner nodes.

The node cache is intended to function as a persistent storage across multiple CI workflow runs for storing cache data (e.g. ccache).