### PR TITLE
terraform: cnx-zephyr: Set node network subnet to 10.0.0.0/16

### DIFF
--- a/terraform/cnx-zephyr-ci/main.tf
+++ b/terraform/cnx-zephyr-ci/main.tf
@@ -59,6 +59,7 @@ resource "openstack_containerinfra_clustertemplate_v1" "kubernetes_1_23_zephyr_c
     boot_volume_size                 = "20"
     boot_volume_type                 = "fc_r1"
     docker_volume_type               = "fc_r1"
+    fixed_subnet_cidr                = "10.0.0.0/16"
   }
 }
 

--- a/terraform/cnx-zephyr-test/main.tf
+++ b/terraform/cnx-zephyr-test/main.tf
@@ -59,6 +59,7 @@ resource "openstack_containerinfra_clustertemplate_v1" "kubernetes_1_23_zephyr_t
     boot_volume_size                 = "20"
     boot_volume_type                 = "fc_r1"
     docker_volume_type               = "fc_r1"
+    fixed_subnet_cidr                = "10.0.0.0/16"
   }
 }
 


### PR DESCRIPTION
This commit changes the fixed node network subnet from the default value
of 10.0.0.0/24 to 10.0.0.0/16 to improve scalability.