### PR TITLE
cnx-zephyr-ci: Deploy KeyDB Redis cache server

### DIFF
--- a/kubernetes/zephyr-runner-v2/cnx/cnx-keydb-cache/config.yaml
+++ b/kubernetes/zephyr-runner-v2/cnx/cnx-keydb-cache/config.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: keydb-cache-config
+  namespace: keydb-cache
+data:
+  keydb-config: |
+    # Set server thread count to 4.
+    server-threads 4
+
+    # Set maximum memory to 224 GiB.
+    maxmemory 224gb
+
+    # Evict cache based on Least Recently Used (LRU).
+    maxmemory-policy allkeys-lru
+
+    # Disable RDB and AOF persistence.
+    save ""
+    appendonly no

--- a/kubernetes/zephyr-runner-v2/cnx/cnx-keydb-cache/keydb.yaml
+++ b/kubernetes/zephyr-runner-v2/cnx/cnx-keydb-cache/keydb.yaml
@@ -1,0 +1,118 @@
+# keydb-cache-1 Pod
+apiVersion: v1
+kind: Pod
+metadata:
+  name: keydb-cache-1
+  namespace: keydb-cache
+  labels:
+    app.kubernetes.io/name: keydb-cache-1
+spec:
+  containers:
+  - name: keydb
+    image: ghcr.io/centrinix/keydb:v6.3.4.cnx
+    ports:
+    - containerPort: 6379
+    resources:
+      limits:
+        cpu: "16.0"
+        memory: "256Gi"
+      requests:
+        cpu: "15.0"
+        memory: "224Gi"
+    volumeMounts:
+    - mountPath: /data
+      name: data
+    - mountPath: /etc/keydb
+      name: config
+  volumes:
+  - name: data
+    persistentVolumeClaim:
+      claimName: keydb-cache-1-data
+  - name: config
+    configMap:
+      name: keydb-cache-config
+      items:
+      - key: keydb-config
+        path: keydb.conf
+  nodeSelector:
+    magnum.openstack.org/role: cache
+
+---
+# keydb-cache-2 Pod
+apiVersion: v1
+kind: Pod
+metadata:
+  name: keydb-cache-2
+  namespace: keydb-cache
+  labels:
+    app.kubernetes.io/name: keydb-cache-2
+spec:
+  containers:
+  - name: keydb
+    image: ghcr.io/centrinix/keydb:v6.3.4.cnx
+    ports:
+    - containerPort: 6379
+    resources:
+      limits:
+        cpu: "16.0"
+        memory: "256Gi"
+      requests:
+        cpu: "15.0"
+        memory: "224Gi"
+    volumeMounts:
+    - mountPath: /data
+      name: data
+    - mountPath: /etc/keydb
+      name: config
+  volumes:
+  - name: data
+    persistentVolumeClaim:
+      claimName: keydb-cache-2-data
+  - name: config
+    configMap:
+      name: keydb-cache-config
+      items:
+      - key: keydb-config
+        path: keydb.conf
+  nodeSelector:
+    magnum.openstack.org/role: cache
+
+---
+# keydb-cache-3 Pod
+apiVersion: v1
+kind: Pod
+metadata:
+  name: keydb-cache-3
+  namespace: keydb-cache
+  labels:
+    app.kubernetes.io/name: keydb-cache-3
+spec:
+  containers:
+  - name: keydb
+    image: ghcr.io/centrinix/keydb:v6.3.4.cnx
+    ports:
+    - containerPort: 6379
+    resources:
+      limits:
+        cpu: "16.0"
+        memory: "256Gi"
+      requests:
+        cpu: "15.0"
+        memory: "224Gi"
+    volumeMounts:
+    - mountPath: /data
+      name: data
+    - mountPath: /etc/keydb
+      name: config
+  volumes:
+  - name: data
+    persistentVolumeClaim:
+      claimName: keydb-cache-3-data
+  - name: config
+    configMap:
+      name: keydb-cache-config
+      items:
+      - key: keydb-config
+        path: keydb.conf
+  nodeSelector:
+    magnum.openstack.org/role: cache

--- a/kubernetes/zephyr-runner-v2/cnx/cnx-keydb-cache/pvc.yaml
+++ b/kubernetes/zephyr-runner-v2/cnx/cnx-keydb-cache/pvc.yaml
@@ -1,0 +1,40 @@
+# keydb-cache-1-data Persistent Volume Claim
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: keydb-cache-1-data
+  namespace: keydb-cache
+spec:
+  storageClassName: openebs-hostpath
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 800Gi
+
+---
+# keydb-cache-2-data Persistent Volume Claim
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: keydb-cache-2-data
+  namespace: keydb-cache
+spec:
+  storageClassName: openebs-hostpath
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 800Gi
+
+---
+# keydb-cache-3-data Persistent Volume Claim
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: keydb-cache-3-data
+  namespace: keydb-cache
+spec:
+  storageClassName: openebs-hostpath
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 800Gi

--- a/kubernetes/zephyr-runner-v2/cnx/cnx-keydb-cache/services.yaml
+++ b/kubernetes/zephyr-runner-v2/cnx/cnx-keydb-cache/services.yaml
@@ -1,0 +1,43 @@
+# cache-1 Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: cache-1
+  namespace: keydb-cache
+spec:
+  type: NodePort
+  selector:
+    app.kubernetes.io/name: keydb-cache-1
+  ports:
+  - port: 6379
+    targetPort: 6379
+
+---
+# cache-2 Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: cache-2
+  namespace: keydb-cache
+spec:
+  type: NodePort
+  selector:
+    app.kubernetes.io/name: keydb-cache-2
+  ports:
+  - port: 6379
+    targetPort: 6379
+
+---
+# cache-3 Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: cache-3
+  namespace: keydb-cache
+spec:
+  type: NodePort
+  selector:
+    app.kubernetes.io/name: keydb-cache-3
+  ports:
+  - port: 6379
+    targetPort: 6379

--- a/terraform/cnx-zephyr-ci/README.md
+++ b/terraform/cnx-zephyr-ci/README.md
@@ -50,6 +50,9 @@ terraform apply -target=openstack_containerinfra_cluster_v1.zephyr_ci
 3. Deploy node groups:
 
 ```
+terraform apply -target=openstack_containerinfra_nodegroup_v1.az1_cache
+terraform apply -target=openstack_containerinfra_nodegroup_v1.az2_cache
+terraform apply -target=openstack_containerinfra_nodegroup_v1.az3_cache
 terraform apply -target=openstack_containerinfra_nodegroup_v1.az1_linux_x64
 terraform apply -target=openstack_containerinfra_nodegroup_v1.az2_linux_x64
 terraform apply -target=openstack_containerinfra_nodegroup_v1.az3_linux_x64

--- a/terraform/cnx-zephyr-ci/main.tf
+++ b/terraform/cnx-zephyr-ci/main.tf
@@ -260,6 +260,64 @@ resource "helm_release" "openebs" {
   depends_on = [kubectl_manifest.cnx_privileged_manifest]
 }
 
+
+# KeyDB Redis Cache Installation
+## keydb-cache Namespace
+resource "kubernetes_namespace" "keydb_cache" {
+  metadata {
+    name = "keydb-cache"
+  }
+  depends_on = [helm_release.openebs]
+}
+
+## Configurations
+data "kubectl_path_documents" "keydb_cache_config_manifests" {
+  pattern = "../../kubernetes/zephyr-runner-v2/cnx/cnx-keydb-cache/config.yaml"
+}
+
+resource "kubectl_manifest" "keydb_cache_config_manifest" {
+  count      = length(data.kubectl_path_documents.keydb_cache_config_manifests.documents)
+  yaml_body  = element(data.kubectl_path_documents.keydb_cache_config_manifests.documents, count.index)
+  wait       = true
+  depends_on = [kubernetes_namespace.keydb_cache]
+}
+
+## Persistent Volume Claims
+data "kubectl_path_documents" "keydb_cache_pvc_manifests" {
+  pattern = "../../kubernetes/zephyr-runner-v2/cnx/cnx-keydb-cache/pvc.yaml"
+}
+
+resource "kubectl_manifest" "keydb_cache_pvc_manifest" {
+  count      = length(data.kubectl_path_documents.keydb_cache_pvc_manifests.documents)
+  yaml_body  = element(data.kubectl_path_documents.keydb_cache_pvc_manifests.documents, count.index)
+  wait       = true
+  depends_on = [kubernetes_namespace.keydb_cache]
+}
+
+## KeyDB Pods
+data "kubectl_path_documents" "keydb_cache_keydb_manifests" {
+  pattern = "../../kubernetes/zephyr-runner-v2/cnx/cnx-keydb-cache/keydb.yaml"
+}
+
+resource "kubectl_manifest" "keydb_cache_keydb_manifest" {
+  count      = length(data.kubectl_path_documents.keydb_cache_keydb_manifests.documents)
+  yaml_body  = element(data.kubectl_path_documents.keydb_cache_keydb_manifests.documents, count.index)
+  wait       = true
+  depends_on = [kubernetes_namespace.keydb_cache]
+}
+
+## Services
+data "kubectl_path_documents" "keydb_cache_services_manifests" {
+  pattern = "../../kubernetes/zephyr-runner-v2/cnx/cnx-keydb-cache/services.yaml"
+}
+
+resource "kubectl_manifest" "keydb_cache_services_manifest" {
+  count      = length(data.kubectl_path_documents.keydb_cache_services_manifests.documents)
+  yaml_body  = element(data.kubectl_path_documents.keydb_cache_services_manifests.documents, count.index)
+  wait       = true
+  depends_on = [kubernetes_namespace.keydb_cache]
+}
+
 # Actions Runner Controller (ARC) Installation
 ## arc-runners Namespace
 resource "kubernetes_namespace" "arc_runners" {

--- a/terraform/cnx-zephyr-ci/main.tf
+++ b/terraform/cnx-zephyr-ci/main.tf
@@ -82,6 +82,72 @@ resource "openstack_containerinfra_cluster_v1" "zephyr_ci" {
   depends_on          = [openstack_containerinfra_clustertemplate_v1.kubernetes_1_23_zephyr_ci]
 }
 
+# az1-cache Node Group
+resource "openstack_containerinfra_nodegroup_v1" "az1_cache" {
+  name                = "az1-cache"
+  cluster_id          = openstack_containerinfra_cluster_v1.zephyr_ci.id
+  image_id            = "fedora-coreos-35.20220116.3.0-x86_64"
+  flavor_id           = "x2.4xlarge"
+  docker_volume_size  = 1000
+  role                = "cache"
+  node_count          = 1
+  merge_labels        = true
+
+  labels = {
+    availability_zone = "az1"
+  }
+
+  lifecycle {
+    ignore_changes = [node_count]
+  }
+
+  depends_on          = [openstack_containerinfra_cluster_v1.zephyr_ci]
+}
+
+# az2-cache Node Group
+resource "openstack_containerinfra_nodegroup_v1" "az2_cache" {
+  name                = "az2-cache"
+  cluster_id          = openstack_containerinfra_cluster_v1.zephyr_ci.id
+  image_id            = "fedora-coreos-35.20220116.3.0-x86_64"
+  flavor_id           = "x2.4xlarge"
+  docker_volume_size  = 1000
+  role                = "cache"
+  node_count          = 1
+  merge_labels        = true
+
+  labels = {
+    availability_zone = "az2"
+  }
+
+  lifecycle {
+    ignore_changes = [node_count]
+  }
+
+  depends_on          = [openstack_containerinfra_cluster_v1.zephyr_ci]
+}
+
+# az3-cache Node Group
+resource "openstack_containerinfra_nodegroup_v1" "az3_cache" {
+  name                = "az3-cache"
+  cluster_id          = openstack_containerinfra_cluster_v1.zephyr_ci.id
+  image_id            = "fedora-coreos-35.20220116.3.0-x86_64"
+  flavor_id           = "x2.4xlarge"
+  docker_volume_size  = 1000
+  role                = "cache"
+  node_count          = 1
+  merge_labels        = true
+
+  labels = {
+    availability_zone = "az3"
+  }
+
+  lifecycle {
+    ignore_changes = [node_count]
+  }
+
+  depends_on          = [openstack_containerinfra_cluster_v1.zephyr_ci]
+}
+
 # az1-linux-x64 Node Group
 resource "openstack_containerinfra_nodegroup_v1" "az1_linux_x64" {
   name                = "az1-linux-x64"


### PR DESCRIPTION
Deploy KeyDB-based Redis cache server in the cnx-zephyr-ci Kubernetes cluster.

Closes https://github.com/zephyrproject-rtos/infrastructure/issues/176