### PR TITLE
zephyr-runner-v2: Use rawfile-localpv for work volume backend

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "terraform-aws-eks-blueprints"]
 	path = terraform/zephyr-aws-blueprints/terraform-aws-eks-blueprints
 	url = https://github.com/zephyrproject-rtos/terraform-aws-eks-blueprints.git
+[submodule "kubernetes/zephyr-runner-v2/cnx/cnx-rawfile-localpv/openebs-rawfile-localpv"]
+	path = kubernetes/zephyr-runner-v2/cnx/cnx-rawfile-localpv/openebs-rawfile-localpv
+	url = https://github.com/Centrinix/openebs-rawfile-localpv.git

--- a/kubernetes/zephyr-runner-v2/cnx/cnx-rawfile-localpv/values.yaml
+++ b/kubernetes/zephyr-runner-v2/cnx/cnx-rawfile-localpv/values.yaml
@@ -1,0 +1,2 @@
+node:
+  dataDirPath: /var/lib/docker/openebs/rawfile

--- a/kubernetes/zephyr-runner-v2/cnx/test-runner-scale-sets/test-runner-v2-linux-arm64-4xlarge-cnx/values.yaml
+++ b/kubernetes/zephyr-runner-v2/cnx/test-runner-scale-sets/test-runner-v2-linux-arm64-4xlarge-cnx/values.yaml
@@ -23,7 +23,7 @@ containerMode:
   type: "kubernetes"  ## type can be set to dind or kubernetes
   kubernetesModeWorkVolumeClaim:
     accessModes: ["ReadWriteOnce"]
-    storageClassName: "openebs-hostpath"
+    storageClassName: "rawfile-localpv"
     resources:
       requests:
         # Size of workspace
@@ -33,6 +33,13 @@ containerMode:
 ## For reference: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec
 template:
   spec:
+    initContainers:
+    - name: set-workdir-permission
+      image: ghcr.io/actions/actions-runner:2.313.0
+      command: ["sudo", "chown", "runner:runner", "/home/runner/_work"]
+      volumeMounts:
+      - name: work
+        mountPath: /home/runner/_work
     containers:
     - name: runner
       image: ghcr.io/actions/actions-runner:2.313.0

--- a/kubernetes/zephyr-runner-v2/cnx/test-runner-scale-sets/test-runner-v2-linux-x64-4xlarge-cnx/values.yaml
+++ b/kubernetes/zephyr-runner-v2/cnx/test-runner-scale-sets/test-runner-v2-linux-x64-4xlarge-cnx/values.yaml
@@ -23,7 +23,7 @@ containerMode:
   type: "kubernetes"  ## type can be set to dind or kubernetes
   kubernetesModeWorkVolumeClaim:
     accessModes: ["ReadWriteOnce"]
-    storageClassName: "openebs-hostpath"
+    storageClassName: "rawfile-localpv"
     resources:
       requests:
         # Size of workspace
@@ -33,6 +33,13 @@ containerMode:
 ## For reference: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec
 template:
   spec:
+    initContainers:
+    - name: set-workdir-permission
+      image: ghcr.io/actions/actions-runner:2.313.0
+      command: ["sudo", "chown", "runner:runner", "/home/runner/_work"]
+      volumeMounts:
+      - name: work
+        mountPath: /home/runner/_work
     containers:
     - name: runner
       image: ghcr.io/actions/actions-runner:2.313.0

--- a/kubernetes/zephyr-runner-v2/cnx/zephyr-runner-scale-sets/zephyr-runner-v2-linux-arm64-4xlarge-cnx/values.yaml
+++ b/kubernetes/zephyr-runner-v2/cnx/zephyr-runner-scale-sets/zephyr-runner-v2-linux-arm64-4xlarge-cnx/values.yaml
@@ -23,7 +23,7 @@ containerMode:
   type: "kubernetes"  ## type can be set to dind or kubernetes
   kubernetesModeWorkVolumeClaim:
     accessModes: ["ReadWriteOnce"]
-    storageClassName: "openebs-hostpath"
+    storageClassName: "rawfile-localpv"
     resources:
       requests:
         # Size of workspace
@@ -33,6 +33,13 @@ containerMode:
 ## For reference: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec
 template:
   spec:
+    initContainers:
+    - name: set-workdir-permission
+      image: ghcr.io/actions/actions-runner:2.313.0
+      command: ["sudo", "chown", "runner:runner", "/home/runner/_work"]
+      volumeMounts:
+      - name: work
+        mountPath: /home/runner/_work
     containers:
     - name: runner
       image: ghcr.io/actions/actions-runner:2.313.0

--- a/kubernetes/zephyr-runner-v2/cnx/zephyr-runner-scale-sets/zephyr-runner-v2-linux-x64-4xlarge-cnx/values.yaml
+++ b/kubernetes/zephyr-runner-v2/cnx/zephyr-runner-scale-sets/zephyr-runner-v2-linux-x64-4xlarge-cnx/values.yaml
@@ -23,7 +23,7 @@ containerMode:
   type: "kubernetes"  ## type can be set to dind or kubernetes
   kubernetesModeWorkVolumeClaim:
     accessModes: ["ReadWriteOnce"]
-    storageClassName: "openebs-hostpath"
+    storageClassName: "rawfile-localpv"
     resources:
       requests:
         # Size of workspace
@@ -33,6 +33,13 @@ containerMode:
 ## For reference: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec
 template:
   spec:
+    initContainers:
+    - name: set-workdir-permission
+      image: ghcr.io/actions/actions-runner:2.313.0
+      command: ["sudo", "chown", "runner:runner", "/home/runner/_work"]
+      volumeMounts:
+      - name: work
+        mountPath: /home/runner/_work
     containers:
     - name: runner
       image: ghcr.io/actions/actions-runner:2.313.0

--- a/terraform/cnx-zephyr-ci/main.tf
+++ b/terraform/cnx-zephyr-ci/main.tf
@@ -260,6 +260,15 @@ resource "helm_release" "openebs" {
   depends_on = [kubectl_manifest.cnx_privileged_manifest]
 }
 
+# OpenEBS rawfile-localpv Installation
+resource "helm_release" "openebs_rawfile_localpv" {
+  name       = "rawfile-csi"
+  namespace  = "kube-system"
+  chart      = "../../kubernetes/zephyr-runner-v2/cnx/cnx-rawfile-localpv/openebs-rawfile-localpv/deploy/charts/rawfile-csi"
+  version    = "0.8.0"
+  values     = ["${file("../../kubernetes/zephyr-runner-v2/cnx/cnx-rawfile-localpv/values.yaml")}"]
+  depends_on = [kubectl_manifest.cnx_privileged_manifest]
+}
 
 # KeyDB Redis Cache Installation
 ## keydb-cache Namespace
@@ -324,7 +333,7 @@ resource "kubernetes_namespace" "arc_runners" {
   metadata {
     name = "arc-runners"
   }
-  depends_on = [helm_release.openebs]
+  depends_on = [helm_release.openebs, helm_release.openebs_rawfile_localpv]
 }
 
 ## GitHub App Secret

--- a/terraform/cnx-zephyr-test/main.tf
+++ b/terraform/cnx-zephyr-test/main.tf
@@ -150,13 +150,23 @@ resource "helm_release" "openebs" {
   depends_on = [kubectl_manifest.cnx_privileged_manifest]
 }
 
+# OpenEBS rawfile-localpv Installation
+resource "helm_release" "openebs_rawfile_localpv" {
+  name       = "rawfile-csi"
+  namespace  = "kube-system"
+  chart      = "../../kubernetes/zephyr-runner-v2/cnx/cnx-rawfile-localpv/openebs-rawfile-localpv/deploy/charts/rawfile-csi"
+  version    = "0.8.0"
+  values     = ["${file("../../kubernetes/zephyr-runner-v2/cnx/cnx-rawfile-localpv/values.yaml")}"]
+  depends_on = [kubectl_manifest.cnx_privileged_manifest]
+}
+
 # Actions Runner Controller (ARC) Installation
 ## arc-runners Namespace
 resource "kubernetes_namespace" "arc_runners" {
   metadata {
     name = "arc-runners"
   }
-  depends_on = [helm_release.openebs]
+  depends_on = [helm_release.openebs, helm_release.openebs_rawfile_localpv]
 }
 
 ## GitHub App Secret


### PR DESCRIPTION
Use `rawfile-localpv` instead of `openebs-hostpath` for work volume backend because the latter utilises the node host filesystem for storing build artifacts and the cleanup process takes too long to be viable for large CI runs (e.g. weekly build runs with millions of files).