### PR TITLE
zephyr-runner-v2: Increase boot volume size and use it for ephemeral storage

### DIFF
--- a/kubernetes/zephyr-runner-v2/aws/test-runner-scale-sets/test-runner-v2-linux-arm64-4xlarge-aws/values.yaml
+++ b/kubernetes/zephyr-runner-v2/aws/test-runner-scale-sets/test-runner-v2-linux-arm64-4xlarge-aws/values.yaml
@@ -27,7 +27,7 @@ containerMode:
     resources:
       requests:
         # Size of workspace
-        storage: 20Gi
+        storage: 180Gi
 
 # template is the PodSpec for each runner Pod
 # For reference: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec

--- a/kubernetes/zephyr-runner-v2/aws/test-runner-scale-sets/test-runner-v2-linux-x64-4xlarge-aws/values.yaml
+++ b/kubernetes/zephyr-runner-v2/aws/test-runner-scale-sets/test-runner-v2-linux-x64-4xlarge-aws/values.yaml
@@ -27,7 +27,7 @@ containerMode:
     resources:
       requests:
         # Size of workspace
-        storage: 20Gi
+        storage: 180Gi
 
 # template is the PodSpec for each runner Pod
 # For reference: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec

--- a/kubernetes/zephyr-runner-v2/aws/zephyr-runner-scale-sets/zephyr-runner-v2-linux-x64-4xlarge-aws/values.yaml
+++ b/kubernetes/zephyr-runner-v2/aws/zephyr-runner-scale-sets/zephyr-runner-v2-linux-x64-4xlarge-aws/values.yaml
@@ -27,7 +27,7 @@ containerMode:
     resources:
       requests:
         # Size of workspace
-        storage: 20Gi
+        storage: 180Gi
 
 # template is the PodSpec for each runner Pod
 # For reference: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec

--- a/kubernetes/zephyr-runner-v2/cnx/cnx-openebs/values.yaml
+++ b/kubernetes/zephyr-runner-v2/cnx/cnx-openebs/values.yaml
@@ -1,18 +1,14 @@
+# Set OpenEBS base paths to under containerd mount, which is accessible by the
+# node kubelet.
 varDirectoryPath:
-  baseDir: "/var/lib/docker/openebs"
+  baseDir: "/var/lib/containerd/openebs"
 
 localprovisioner:
-  # Set OpenEBS local PV base path to under Docker volume mount because the
-  # node root volume is relatively small and the primary ephemeral storage is
-  # intended to be the Docker volume. In addition, the Centrinix Kubernetes
-  # deployment places kubelet into a container and does not map the default
-  # OpenEBS var directory into the kubelet container, which leads to kubelet
-  # being unable to verify the local PV hostPath volume mounts.
-  basePath: "/var/lib/docker/openebs/local"
+  basePath: "/var/lib/containerd/openebs/local"
 
 ndm:
   sparse:
-    path: "/var/lib/docker/openebs/sparse"
+    path: "/var/lib/containerd/openebs/sparse"
 
 jiva:
-  defaultStoragePath: "/var/lib/docker/openebs"
+  defaultStoragePath: "/var/lib/containerd/openebs"

--- a/kubernetes/zephyr-runner-v2/cnx/cnx-rawfile-localpv/values.yaml
+++ b/kubernetes/zephyr-runner-v2/cnx/cnx-rawfile-localpv/values.yaml
@@ -1,2 +1,2 @@
 node:
-  dataDirPath: /var/lib/docker/openebs/rawfile
+  dataDirPath: /var/lib/containerd/openebs/rawfile

--- a/kubernetes/zephyr-runner-v2/cnx/test-runner-scale-sets/test-runner-v2-linux-arm64-4xlarge-cnx/values.yaml
+++ b/kubernetes/zephyr-runner-v2/cnx/test-runner-scale-sets/test-runner-v2-linux-arm64-4xlarge-cnx/values.yaml
@@ -27,7 +27,7 @@ containerMode:
     resources:
       requests:
         # Size of workspace
-        storage: 20Gi
+        storage: 180Gi
 
 ## template is the PodSpec for each runner Pod
 ## For reference: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec

--- a/kubernetes/zephyr-runner-v2/cnx/test-runner-scale-sets/test-runner-v2-linux-x64-4xlarge-cnx/values.yaml
+++ b/kubernetes/zephyr-runner-v2/cnx/test-runner-scale-sets/test-runner-v2-linux-x64-4xlarge-cnx/values.yaml
@@ -27,7 +27,7 @@ containerMode:
     resources:
       requests:
         # Size of workspace
-        storage: 20Gi
+        storage: 180Gi
 
 ## template is the PodSpec for each runner Pod
 ## For reference: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec

--- a/kubernetes/zephyr-runner-v2/cnx/zephyr-runner-scale-sets/zephyr-runner-v2-linux-arm64-4xlarge-cnx/values.yaml
+++ b/kubernetes/zephyr-runner-v2/cnx/zephyr-runner-scale-sets/zephyr-runner-v2-linux-arm64-4xlarge-cnx/values.yaml
@@ -27,7 +27,7 @@ containerMode:
     resources:
       requests:
         # Size of workspace
-        storage: 20Gi
+        storage: 180Gi
 
 ## template is the PodSpec for each runner Pod
 ## For reference: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec

--- a/kubernetes/zephyr-runner-v2/cnx/zephyr-runner-scale-sets/zephyr-runner-v2-linux-x64-4xlarge-cnx/values.yaml
+++ b/kubernetes/zephyr-runner-v2/cnx/zephyr-runner-scale-sets/zephyr-runner-v2-linux-x64-4xlarge-cnx/values.yaml
@@ -27,7 +27,7 @@ containerMode:
     resources:
       requests:
         # Size of workspace
-        storage: 20Gi
+        storage: 180Gi
 
 ## template is the PodSpec for each runner Pod
 ## For reference: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec

--- a/terraform/cnx-zephyr-ci/main.tf
+++ b/terraform/cnx-zephyr-ci/main.tf
@@ -56,7 +56,7 @@ resource "openstack_containerinfra_clustertemplate_v1" "kubernetes_1_23_zephyr_c
     container_infra_prefix           = "registry.centrinix.cloud/openstack/"
     node_problem_detector_tag        = "v0.8.15"
     selinux_mode                     = "permissive"
-    boot_volume_size                 = "20"
+    boot_volume_size                 = "200"
     boot_volume_type                 = "fc_r1"
     docker_volume_type               = "fc_r1"
     fixed_subnet_cidr                = "10.0.0.0/16"

--- a/terraform/cnx-zephyr-ci/main.tf
+++ b/terraform/cnx-zephyr-ci/main.tf
@@ -88,12 +88,14 @@ resource "openstack_containerinfra_nodegroup_v1" "az1_cache" {
   cluster_id          = openstack_containerinfra_cluster_v1.zephyr_ci.id
   image_id            = "fedora-coreos-35.20220116.3.0-x86_64"
   flavor_id           = "x2.4xlarge"
-  docker_volume_size  = 1000
+  docker_volume_size  = 100
   role                = "cache"
   node_count          = 1
   merge_labels        = true
 
   labels = {
+    boot_volume_size  = "1000"
+    boot_volume_type  = "fc_r1"
     availability_zone = "az1"
   }
 
@@ -110,12 +112,14 @@ resource "openstack_containerinfra_nodegroup_v1" "az2_cache" {
   cluster_id          = openstack_containerinfra_cluster_v1.zephyr_ci.id
   image_id            = "fedora-coreos-35.20220116.3.0-x86_64"
   flavor_id           = "x2.4xlarge"
-  docker_volume_size  = 1000
+  docker_volume_size  = 100
   role                = "cache"
   node_count          = 1
   merge_labels        = true
 
   labels = {
+    boot_volume_size  = "1000"
+    boot_volume_type  = "fc_r1"
     availability_zone = "az2"
   }
 
@@ -132,12 +136,14 @@ resource "openstack_containerinfra_nodegroup_v1" "az3_cache" {
   cluster_id          = openstack_containerinfra_cluster_v1.zephyr_ci.id
   image_id            = "fedora-coreos-35.20220116.3.0-x86_64"
   flavor_id           = "x2.4xlarge"
-  docker_volume_size  = 1000
+  docker_volume_size  = 100
   role                = "cache"
   node_count          = 1
   merge_labels        = true
 
   labels = {
+    boot_volume_size  = "1000"
+    boot_volume_type  = "fc_r1"
     availability_zone = "az3"
   }
 

--- a/terraform/cnx-zephyr-test/main.tf
+++ b/terraform/cnx-zephyr-test/main.tf
@@ -56,7 +56,7 @@ resource "openstack_containerinfra_clustertemplate_v1" "kubernetes_1_23_zephyr_t
     container_infra_prefix           = "registry.centrinix.cloud/openstack/"
     node_problem_detector_tag        = "v0.8.15"
     selinux_mode                     = "permissive"
-    boot_volume_size                 = "20"
+    boot_volume_size                 = "200"
     boot_volume_type                 = "fc_r1"
     docker_volume_type               = "fc_r1"
     fixed_subnet_cidr                = "10.0.0.0/16"


### PR DESCRIPTION
This series increases the size of the boot volume to 200GB and moves the main ephemeral data storage from the Docker volume (`/var/lib/docker`) to the boot volume (`/`).