### PR TITLE
zephyr-runner-v2: Reduce work volume size to 160GiB

### DIFF
--- a/kubernetes/zephyr-runner-v2/aws/test-runner-scale-sets/test-runner-v2-linux-arm64-4xlarge-aws/values.yaml
+++ b/kubernetes/zephyr-runner-v2/aws/test-runner-scale-sets/test-runner-v2-linux-arm64-4xlarge-aws/values.yaml
@@ -27,7 +27,7 @@ containerMode:
     resources:
       requests:
         # Size of workspace
-        storage: 180Gi
+        storage: 160Gi
 
 # template is the PodSpec for each runner Pod
 # For reference: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec

--- a/kubernetes/zephyr-runner-v2/aws/test-runner-scale-sets/test-runner-v2-linux-x64-4xlarge-aws/values.yaml
+++ b/kubernetes/zephyr-runner-v2/aws/test-runner-scale-sets/test-runner-v2-linux-x64-4xlarge-aws/values.yaml
@@ -27,7 +27,7 @@ containerMode:
     resources:
       requests:
         # Size of workspace
-        storage: 180Gi
+        storage: 160Gi
 
 # template is the PodSpec for each runner Pod
 # For reference: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec

--- a/kubernetes/zephyr-runner-v2/aws/zephyr-runner-scale-sets/zephyr-runner-v2-linux-x64-4xlarge-aws/values.yaml
+++ b/kubernetes/zephyr-runner-v2/aws/zephyr-runner-scale-sets/zephyr-runner-v2-linux-x64-4xlarge-aws/values.yaml
@@ -27,7 +27,7 @@ containerMode:
     resources:
       requests:
         # Size of workspace
-        storage: 180Gi
+        storage: 160Gi
 
 # template is the PodSpec for each runner Pod
 # For reference: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec

--- a/kubernetes/zephyr-runner-v2/cnx/test-runner-scale-sets/test-runner-v2-linux-arm64-4xlarge-cnx/values.yaml
+++ b/kubernetes/zephyr-runner-v2/cnx/test-runner-scale-sets/test-runner-v2-linux-arm64-4xlarge-cnx/values.yaml
@@ -27,7 +27,7 @@ containerMode:
     resources:
       requests:
         # Size of workspace
-        storage: 180Gi
+        storage: 160Gi
 
 ## template is the PodSpec for each runner Pod
 ## For reference: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec

--- a/kubernetes/zephyr-runner-v2/cnx/test-runner-scale-sets/test-runner-v2-linux-x64-4xlarge-cnx/values.yaml
+++ b/kubernetes/zephyr-runner-v2/cnx/test-runner-scale-sets/test-runner-v2-linux-x64-4xlarge-cnx/values.yaml
@@ -27,7 +27,7 @@ containerMode:
     resources:
       requests:
         # Size of workspace
-        storage: 180Gi
+        storage: 160Gi
 
 ## template is the PodSpec for each runner Pod
 ## For reference: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec

--- a/kubernetes/zephyr-runner-v2/cnx/zephyr-runner-scale-sets/zephyr-runner-v2-linux-arm64-4xlarge-cnx/values.yaml
+++ b/kubernetes/zephyr-runner-v2/cnx/zephyr-runner-scale-sets/zephyr-runner-v2-linux-arm64-4xlarge-cnx/values.yaml
@@ -27,7 +27,7 @@ containerMode:
     resources:
       requests:
         # Size of workspace
-        storage: 180Gi
+        storage: 160Gi
 
 ## template is the PodSpec for each runner Pod
 ## For reference: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec

--- a/kubernetes/zephyr-runner-v2/cnx/zephyr-runner-scale-sets/zephyr-runner-v2-linux-x64-4xlarge-cnx/values.yaml
+++ b/kubernetes/zephyr-runner-v2/cnx/zephyr-runner-scale-sets/zephyr-runner-v2-linux-x64-4xlarge-cnx/values.yaml
@@ -27,7 +27,7 @@ containerMode:
     resources:
       requests:
         # Size of workspace
-        storage: 180Gi
+        storage: 160Gi
 
 ## template is the PodSpec for each runner Pod
 ## For reference: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec


### PR DESCRIPTION
This commit reduces the zephyr-runner v2 work volume size from 180GiB to 160GiB because the system logs and Kubernetes node service container layers may take up more than 20GiB of disk space.

This effectively reserves 40GiB out of 200GiB for the node system usage.