### PR TITLE
zephyr-runner-v2: Update actions-runner to 2.319.1

### DIFF
--- a/kubernetes/zephyr-runner-v2/aws/test-runner-scale-sets/test-runner-v2-linux-arm64-4xlarge-aws/values.yaml
+++ b/kubernetes/zephyr-runner-v2/aws/test-runner-scale-sets/test-runner-v2-linux-arm64-4xlarge-aws/values.yaml
@@ -35,7 +35,7 @@ template:
   spec:
     containers:
     - name: runner
-      image: ghcr.io/actions/actions-runner:2.317.0
+      image: ghcr.io/actions/actions-runner:2.319.1
       command: ["/home/runner/run.sh"]
       env:
       # Allow running workflow jobs outside a container.

--- a/kubernetes/zephyr-runner-v2/aws/test-runner-scale-sets/test-runner-v2-linux-x64-4xlarge-aws/values.yaml
+++ b/kubernetes/zephyr-runner-v2/aws/test-runner-scale-sets/test-runner-v2-linux-x64-4xlarge-aws/values.yaml
@@ -35,7 +35,7 @@ template:
   spec:
     containers:
     - name: runner
-      image: ghcr.io/actions/actions-runner:2.317.0
+      image: ghcr.io/actions/actions-runner:2.319.1
       command: ["/home/runner/run.sh"]
       env:
       # Allow running workflow jobs outside a container.

--- a/kubernetes/zephyr-runner-v2/aws/zephyr-runner-scale-sets/zephyr-runner-v2-linux-x64-4xlarge-aws/values.yaml
+++ b/kubernetes/zephyr-runner-v2/aws/zephyr-runner-scale-sets/zephyr-runner-v2-linux-x64-4xlarge-aws/values.yaml
@@ -35,7 +35,7 @@ template:
   spec:
     containers:
     - name: runner
-      image: ghcr.io/actions/actions-runner:2.317.0
+      image: ghcr.io/actions/actions-runner:2.319.1
       command: ["/home/runner/run.sh"]
       env:
       # Allow running workflow jobs outside a container.

--- a/kubernetes/zephyr-runner-v2/cnx/test-runner-scale-sets/test-runner-v2-linux-arm64-4xlarge-cnx/values.yaml
+++ b/kubernetes/zephyr-runner-v2/cnx/test-runner-scale-sets/test-runner-v2-linux-arm64-4xlarge-cnx/values.yaml
@@ -35,14 +35,14 @@ template:
   spec:
     initContainers:
     - name: set-workdir-permission
-      image: ghcr.io/actions/actions-runner:2.317.0
+      image: ghcr.io/actions/actions-runner:2.319.1
       command: ["sudo", "chown", "runner:runner", "/home/runner/_work"]
       volumeMounts:
       - name: work
         mountPath: /home/runner/_work
     containers:
     - name: runner
-      image: ghcr.io/actions/actions-runner:2.317.0
+      image: ghcr.io/actions/actions-runner:2.319.1
       command: ["/home/runner/run.sh"]
       env:
       # Allow running workflow jobs outside a container.

--- a/kubernetes/zephyr-runner-v2/cnx/test-runner-scale-sets/test-runner-v2-linux-x64-4xlarge-cnx/values.yaml
+++ b/kubernetes/zephyr-runner-v2/cnx/test-runner-scale-sets/test-runner-v2-linux-x64-4xlarge-cnx/values.yaml
@@ -35,14 +35,14 @@ template:
   spec:
     initContainers:
     - name: set-workdir-permission
-      image: ghcr.io/actions/actions-runner:2.317.0
+      image: ghcr.io/actions/actions-runner:2.319.1
       command: ["sudo", "chown", "runner:runner", "/home/runner/_work"]
       volumeMounts:
       - name: work
         mountPath: /home/runner/_work
     containers:
     - name: runner
-      image: ghcr.io/actions/actions-runner:2.317.0
+      image: ghcr.io/actions/actions-runner:2.319.1
       command: ["/home/runner/run.sh"]
       env:
       # Allow running workflow jobs outside a container.

--- a/kubernetes/zephyr-runner-v2/cnx/zephyr-runner-scale-sets/zephyr-runner-v2-linux-arm64-4xlarge-cnx/values.yaml
+++ b/kubernetes/zephyr-runner-v2/cnx/zephyr-runner-scale-sets/zephyr-runner-v2-linux-arm64-4xlarge-cnx/values.yaml
@@ -35,14 +35,14 @@ template:
   spec:
     initContainers:
     - name: set-workdir-permission
-      image: ghcr.io/actions/actions-runner:2.317.0
+      image: ghcr.io/actions/actions-runner:2.319.1
       command: ["sudo", "chown", "runner:runner", "/home/runner/_work"]
       volumeMounts:
       - name: work
         mountPath: /home/runner/_work
     containers:
     - name: runner
-      image: ghcr.io/actions/actions-runner:2.317.0
+      image: ghcr.io/actions/actions-runner:2.319.1
       command: ["/home/runner/run.sh"]
       env:
       # Allow running workflow jobs outside a container.

--- a/kubernetes/zephyr-runner-v2/cnx/zephyr-runner-scale-sets/zephyr-runner-v2-linux-x64-4xlarge-cnx/values.yaml
+++ b/kubernetes/zephyr-runner-v2/cnx/zephyr-runner-scale-sets/zephyr-runner-v2-linux-x64-4xlarge-cnx/values.yaml
@@ -35,14 +35,14 @@ template:
   spec:
     initContainers:
     - name: set-workdir-permission
-      image: ghcr.io/actions/actions-runner:2.317.0
+      image: ghcr.io/actions/actions-runner:2.319.1
       command: ["sudo", "chown", "runner:runner", "/home/runner/_work"]
       volumeMounts:
       - name: work
         mountPath: /home/runner/_work
     containers:
     - name: runner
-      image: ghcr.io/actions/actions-runner:2.317.0
+      image: ghcr.io/actions/actions-runner:2.319.1
       command: ["/home/runner/run.sh"]
       env:
       # Allow running workflow jobs outside a container.


### PR DESCRIPTION
This commit updates the zephyr-runner v2 deployment to use the actions-runner 2.319.1.