### PR TITLE
packer: aws-zephyr-runner-node: Upgrade to EKS 1.24 base image

### DIFF
--- a/packer/aws-zephyr-runner-node/aws-zephyr-runner-node-arm64.pkr.hcl
+++ b/packer/aws-zephyr-runner-node/aws-zephyr-runner-node-arm64.pkr.hcl
@@ -10,7 +10,7 @@ packer {
 source "amazon-ebs" "zephyr_runner_node_arm64" {
   region        = "us-east-2"
   ami_name      = "zephyr-runner-node-arm64-{{timestamp}}"
-  source_ami    = "ami-08577b6b086f201e0" # amazon-eks-arm64-node-1.23-v20221112
+  source_ami    = "ami-0b82ae468f7edf62c" # amazon-eks-arm64-node-1.24-v20240209
   instance_type = "c6g.xlarge"
   ssh_username  = "ec2-user"
   launch_block_device_mappings {

--- a/packer/aws-zephyr-runner-node/aws-zephyr-runner-node-x86_64.pkr.hcl
+++ b/packer/aws-zephyr-runner-node/aws-zephyr-runner-node-x86_64.pkr.hcl
@@ -10,7 +10,7 @@ packer {
 source "amazon-ebs" "zephyr_runner_node_x86_64" {
   region        = "us-east-2"
   ami_name      = "zephyr-runner-node-x86_64-{{timestamp}}"
-  source_ami    = "ami-0fcd72f3118e0dd88" # amazon-eks-node-1.23-v20221112
+  source_ami    = "ami-0e3b6e0062e6d8d79" # amazon-eks-node-1.24-v20240209
   instance_type = "c5a.xlarge"
   ssh_username  = "ec2-user"
   launch_block_device_mappings {


### PR DESCRIPTION
This commit upgrades the base image for the aws-zephyr-runner-node images to EKS 1.24.