### PR TITLE
cloud-monitor: Check ready status count for KeyDB cache pods

### DIFF
--- a/.github/workflows/cloud-monitor.yml
+++ b/.github/workflows/cloud-monitor.yml
@@ -230,15 +230,15 @@ jobs:
         kubectl -n keydb-cache get pods
         podList=$(kubectl -n keydb-cache get pods -o json)
 
-        notReadyCount=$(echo "$podList" | jq -r '
+        readyCount=$(echo "$podList" | jq -r '
           [
             .items[].status.conditions[] |
             select(.type == "Ready") |
-            select(.status != "True")
+            select(.status == "True")
           ] | length')
 
-        if [ "$notReadyCount" -gt "0" ]; then
-          .github/log.sh ERROR "cnx: zephyr-ci: Found ${notReadyCount} KeyDB cache pods with not-ready status."
+        if [ "$readyCount" -lt "3" ]; then
+          .github/log.sh ERROR "cnx: zephyr-ci: Found ${readyCount} KeyDB cache pod with ready status (expected 3)."
           exit 911
         fi
 

--- a/.github/workflows/status-publisher.yml
+++ b/.github/workflows/status-publisher.yml
@@ -375,16 +375,16 @@ jobs:
       run: |
         podList=$(kubectl -n keydb-cache get pods -o json)
 
-        notReadyCount=$(echo "$podList" | jq -r '
+        readyCount=$(echo "$podList" | jq -r '
           [
             .items[].status.conditions[] |
             select(.type == "Ready") |
-            select(.status != "True")
+            select(.status == "True")
           ] | length')
 
-        if [ "$notReadyCount" -gt "1" ]; then
+        if [ "$readyCount" -lt "2" ]; then
           status="majorOutage"
-        elif [ "$notReadyCount" -gt "0" ]; then
+        elif [ "$readyCount" -lt "3" ]; then
           status="partialOutage"
         else
           status="operational"


### PR DESCRIPTION
The KeyDB cache status check logic was previously checking for non-ready
pod count, which resulted in the check erroneously reporting
"operational" status when the pods themselves were deleted (e.g. due to
eviction).

This commit updates the check to explicitly check for the ready pod
count.