### PR TITLE
Add Cilicon configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,8 @@ files.
 
     * Packer scripts used for building node machine images.
     * Mainly used for building AMIs for use in the AWS.
+
+* cilicon
+
+    * Cilicon macOS GitHub Actions runner orchestrator configurations. 
+    * Manually deployed to macOS runner nodes.

--- a/cilicon/cilicon.yml
+++ b/cilicon/cilicon.yml
@@ -1,0 +1,8 @@
+source: oci://ghcr.io/zephyrproject-rtos/sdk-build-macos:v0.0.3
+provisioner:
+  type: github
+  config:
+    appId: 1001043
+    organization: zephyrproject-rtos
+    privateKeyPath: ~/zephyr-runner-v2-macos.2024-09-17.private-key.pem
+    runnerGroup: zephyr-runner-v2-macos-arm64-2xlarge


### PR DESCRIPTION
This commit adds the initial Cilicon macOS GitHub Actions runner orchestrator configurations.

Note that these configurations are intended to be manually deployed to the macOS runner nodes and no automation currently exists.