### PR TITLE
zephyr-runner-v2: Upgrade Actions Runner Controller to 0.9.3

### DIFF
--- a/terraform/aws-zephyr-alpha/main.tf
+++ b/terraform/aws-zephyr-alpha/main.tf
@@ -15,7 +15,7 @@ provider "helm" {
 
 # Local Variables
 locals {
-  arc_version = "0.8.2"
+  arc_version = "0.9.3"
 }
 
 # HashiCorp Vault Secrets zephyr-secrets Vault

--- a/terraform/cnx-zephyr-ci/main.tf
+++ b/terraform/cnx-zephyr-ci/main.tf
@@ -358,7 +358,7 @@ resource "kubernetes_secret" "arc_github_app" {
 
 ## Runner Scale Set Controller Deployment
 locals {
-  arc_version = "0.8.2"
+  arc_version = "0.9.3"
 }
 
 resource "helm_release" "arc" {


### PR DESCRIPTION
This commit upgrades the Actions Runner Controller version to 0.9.3 in order to pull in the latest stability fixes.