### PR TITLE
zephyr-runner-v2: Upgrade Actions Runner Controller to 0.11.0

### DIFF
--- a/terraform/aws-zephyr-alpha/main.tf
+++ b/terraform/aws-zephyr-alpha/main.tf
@@ -15,7 +15,7 @@ provider "helm" {
 
 # Local Variables
 locals {
-  arc_version = "0.9.3"
+  arc_version = "0.11.0"
 }
 
 # HashiCorp Vault Secrets zephyr-secrets Vault

--- a/terraform/cnx-zephyr-ci/main.tf
+++ b/terraform/cnx-zephyr-ci/main.tf
@@ -358,7 +358,7 @@ resource "kubernetes_secret" "arc_github_app" {
 
 ## Runner Scale Set Controller Deployment
 locals {
-  arc_version = "0.9.3"
+  arc_version = "0.11.0"
 }
 
 resource "helm_release" "arc" {


### PR DESCRIPTION
This commit upgrades the Actions Runner Controller version to 0.11.0 because the 0.9.3 seems to be no longer compatible with the current GitHub API and cause "random" scaling issues.