### PR TITLE
aws-zephyr-alpha: Increase on-demand node group min size to 2

### DIFF
--- a/terraform/aws-zephyr-alpha/main.tf
+++ b/terraform/aws-zephyr-alpha/main.tf
@@ -38,7 +38,7 @@ module "zephyr_aws_blueprints" {
     }
   ]
 
-  mng_od_linux_x64_2xlarge_min_size     = 1
+  mng_od_linux_x64_2xlarge_min_size     = 2
   mng_od_linux_x64_2xlarge_max_size     = 4
   mng_od_linux_x64_2xlarge_desired_size = 2
 


### PR DESCRIPTION
Increase the `od_linux_x64_2xlarge` main on-demand node group size to 2 in order to ensure redundancy.