### PR TITLE
zephyr-runner-v2: hzr: Set ARM64 Linux runner max count to 5

### DIFF
--- a/kubernetes/zephyr-runner-v2/hzr/zephyr-runner-scale-sets/zephyr-runner-v2-linux-arm64-4xlarge-hzr/values.yaml
+++ b/kubernetes/zephyr-runner-v2/hzr/zephyr-runner-scale-sets/zephyr-runner-v2-linux-arm64-4xlarge-hzr/values.yaml
@@ -5,7 +5,7 @@ runnerScaleSetName: "zrv2-linux-arm64-4xlarge-hzr"
 runnerGroup: "zephyr-runner-v2-linux-arm64-4xlarge"
 
 # maxRunners is the max number of runners the autoscaling runner set will scale up to.
-maxRunners: 100
+maxRunners: 5
 
 # minRunners is the min number of runners the autoscaling runner set will scale down to.
 minRunners: 0


### PR DESCRIPTION
This commit sets the Hetzner ARM64 Linux runner count to 5, which corresponds to the actual hardware capacity in the Hetzner cluster -- note that there is currently 1 RX220 server with 80 cores.

This prevents the GitHub from over-scheduling jobs to the Hetzner ARM64 runner scale set and effectively allows the remaining jobs to be scheduled to the CNX ARM64 runner scale set.