### PR TITLE
zephyr-runner-v2: cnx: Set ARM64 Linux runner max count to 10

### DIFF
--- a/kubernetes/zephyr-runner-v2/cnx/zephyr-runner-scale-sets/zephyr-runner-v2-linux-arm64-4xlarge-cnx/values.yaml
+++ b/kubernetes/zephyr-runner-v2/cnx/zephyr-runner-scale-sets/zephyr-runner-v2-linux-arm64-4xlarge-cnx/values.yaml
@@ -5,7 +5,7 @@ runnerScaleSetName: "zrv2-linux-arm64-4xlarge-cnx"
 runnerGroup: "zephyr-runner-v2-linux-arm64-4xlarge"
 
 # maxRunners is the max number of runners the autoscaling runner set will scale up to.
-maxRunners: 100
+maxRunners: 10
 
 # minRunners is the min number of runners the autoscaling runner set will scale down to.
 minRunners: 0


### PR DESCRIPTION
This commit sets the Centrinix ARM64 Linux runner count to 10, which corresponds to the actual hardware capacity in the Centrinix cluster -- note that there is currently 1 Ampere Mt. Collins server with 160 cores.

This prevents the GitHub from over-scheduling jobs to the Centrinix ARM64 runner scale set and effectively allows the remaining jobs to be scheduled to the HZR ARM64 runner scale set.