### PR TITLE
ci: cloud-monitor: Remove AWS Actions Runner Controller check

### DIFF
--- a/.github/workflows/cloud-monitor.yml
+++ b/.github/workflows/cloud-monitor.yml
@@ -81,24 +81,6 @@ jobs:
           exit 911
         fi
 
-    - name: Check Actions Runner Controller pods
-      if: always()
-      run: |
-        kubectl -n arc-systems get pods
-        podList=$(kubectl -n arc-systems get pods -o json)
-
-        notReadyCount=$(echo "$podList" | jq -r '
-          [
-            .items[].status.conditions[] |
-            select(.type == "Ready") |
-            select(.status != "True")
-          ] | length')
-
-        if [ "$notReadyCount" -gt "0" ]; then
-          .github/log.sh ERROR "aws: zephyr-alpha: Found ${notReadyCount} ARC pods with not-ready status."
-          exit 911
-        fi
-
     - name: Report failure
       if: failure()
       run: |


### PR DESCRIPTION
The AWS Actions Runner Controller (ARC) deployment has been phased out and is no longer active.