### PR TITLE
kubernetes: Add HTTP redirection for stats.zephyrproject.org

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -13,6 +13,10 @@ configuration files for the Zephyr infrastructure components.
 
     * Elastic stack deployment for testing
 
+* http-redirection
+
+    * Ingress deployments for redirecting various HTTP/HTTPS requests
+
 * zephyr-runner-v2
 
     * Next generation GitHub Actions self-hosted runner using GitHub runner

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -13,15 +13,6 @@ configuration files for the Zephyr infrastructure components.
 
     * Elastic stack deployment for testing
 
-* test-runner
-
-    * A sample auto-scaling GitHub Actions self-hosted runner for testing purposes.
-
-* zephyr-runner
-
-    * GitHub Actions self-hosted runner for production use.
-    * To be phased out in the near future.
-
 * zephyr-runner-v2
 
     * Next generation GitHub Actions self-hosted runner using GitHub runner

--- a/kubernetes/http-redirection/redirect-stats-zephyrproject-org.yaml
+++ b/kubernetes/http-redirection/redirect-stats-zephyrproject-org.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: redirect-stats-zephyrproject-org
+  namespace: http-redirection
+  annotations:
+    nginx.ingress.kubernetes.io/permanent-redirect: https://kibana.zephyrproject.io/
+    cert-manager.io/cluster-issuer: cert-manager-letsencrypt-production
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: stats.zephyrproject.org
+  tls:
+  - hosts:
+    - stats.zephyrproject.org
+    secretName: redirect-stats-zephyrproject-org-tls


### PR DESCRIPTION
The Grafana instance at `stats.zephyrproject.org` is now deprecated and has been fully replaced by the Kibana instance at `kibana.zephyrproject.io`.

Redirect `http(s)://stats.zephyrproject.org` to `https://kibana.zephyrproject.org`.

---

Closes https://github.com/zephyrproject-rtos/infrastructure/issues/242