### PR TITLE
github-zephyrproject-rtos: Add script to sync module collaborators

### DIFF
--- a/terraform/github-zephyrproject-rtos/repository/repository-members/acpica.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/acpica.csv
@@ -1,0 +1,4 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,najumon1980,maintain

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/babblesim_base.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/babblesim_base.csv
@@ -1,0 +1,4 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,aescolar,maintain

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/babblesim_ext_2G4_channel_NtNcable.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/babblesim_ext_2G4_channel_NtNcable.csv
@@ -1,0 +1,4 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,aescolar,maintain

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/babblesim_ext_2G4_channel_multiatt.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/babblesim_ext_2G4_channel_multiatt.csv
@@ -1,0 +1,4 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,aescolar,maintain

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/babblesim_ext_2G4_device_WLAN_actmod.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/babblesim_ext_2G4_device_WLAN_actmod.csv
@@ -1,0 +1,4 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,aescolar,maintain

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/babblesim_ext_2G4_device_burst_interferer.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/babblesim_ext_2G4_device_burst_interferer.csv
@@ -1,0 +1,4 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,aescolar,maintain

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/babblesim_ext_2G4_device_playback.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/babblesim_ext_2G4_device_playback.csv
@@ -1,0 +1,4 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,aescolar,maintain

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/babblesim_ext_2G4_libPhyComv1.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/babblesim_ext_2G4_libPhyComv1.csv
@@ -1,0 +1,4 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,aescolar,maintain

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/babblesim_ext_2G4_modem_BLE_simple.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/babblesim_ext_2G4_modem_BLE_simple.csv
@@ -1,0 +1,4 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,aescolar,maintain

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/babblesim_ext_2G4_modem_magic.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/babblesim_ext_2G4_modem_magic.csv
@@ -1,0 +1,4 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,aescolar,maintain

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/babblesim_ext_2G4_phy_v1.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/babblesim_ext_2G4_phy_v1.csv
@@ -1,0 +1,4 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,aescolar,maintain

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/babblesim_ext_libCryptov1.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/babblesim_ext_libCryptov1.csv
@@ -1,0 +1,4 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,aescolar,maintain

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/bsim.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/bsim.csv
@@ -1,0 +1,4 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,aescolar,maintain

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/canopennode.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/canopennode.csv
@@ -1,0 +1,4 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,henrikbrixandersen,maintain

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/chre.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/chre.csv
@@ -1,0 +1,4 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,yperess,maintain

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/cmsis-dsp.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/cmsis-dsp.csv
@@ -1,0 +1,5 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,XenuIsWatching,maintain
+user,stephanosio,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/cmsis-nn.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/cmsis-nn.csv
@@ -1,0 +1,5 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,XenuIsWatching,maintain
+user,stephanosio,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/cmsis.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/cmsis.csv
@@ -1,0 +1,6 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,stephanosio,maintain
+user,microbuilder,push
+user,povergoing,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/cmsis_6.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/cmsis_6.csv
@@ -1,0 +1,6 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,wearyzen,maintain
+user,tomi-font,push
+user,ithinuel,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/edtt.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/edtt.csv
@@ -1,0 +1,6 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,aescolar,maintain
+user,wopu-ot,push
+user,thoh-ot,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/fatfs.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/fatfs.csv
@@ -1,0 +1,4 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,de-nordic,maintain

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/hal_adi.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/hal_adi.csv
@@ -1,0 +1,7 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,MaureenHelm,maintain
+user,ozersa,push
+user,ttmut,push
+user,yasinustunerg,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/hal_afbr.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/hal_afbr.csv
@@ -1,0 +1,7 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,ubieda,maintain
+user,bperseghetti,maintain
+user,PetervdPerk-NXP,push
+user,jgoppert,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/hal_ambiq.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/hal_ambiq.csv
@@ -1,0 +1,6 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,aaronyegx,push
+user,AlessandroLuo,push
+user,RichardSWheatley,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/hal_atmel.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/hal_atmel.csv
@@ -1,0 +1,5 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,nandojve,maintain
+user,pdgendt,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/hal_bouffalolab.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/hal_bouffalolab.csv
@@ -1,0 +1,5 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,nandojve,maintain
+user,VynDragon,maintain

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/hal_cypress.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/hal_cypress.csv
@@ -1,0 +1,7 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,ifyall,maintain
+user,nashif,push
+user,sreeramIfx,push
+user,mcatee-infineon,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/hal_espressif.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/hal_espressif.csv
@@ -1,0 +1,6 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,sylvioalves,maintain
+user,LucasTambor,push
+user,marekmatej,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/hal_ethos_u.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/hal_ethos_u.csv
@@ -1,0 +1,6 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,kristofer-jonsson-arm,maintain
+user,wearyzen,maintain
+user,ithinuel,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/hal_gigadevice.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/hal_gigadevice.csv
@@ -1,0 +1,5 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,nandojve,maintain
+user,soburi,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/hal_infineon.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/hal_infineon.csv
@@ -1,0 +1,8 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,ifyall,maintain
+user,parthitce,push
+user,talih0,push
+user,sreeramIfx,push
+user,mcatee-infineon,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/hal_intel.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/hal_intel.csv
@@ -1,0 +1,6 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,kwd-doodling,maintain
+user,teburd,push
+user,likongintel,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/hal_microchip.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/hal_microchip.csv
@@ -1,0 +1,6 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,jvasanth1,maintain
+user,VenkatKotakonda,push
+user,albertofloyd,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/hal_nordic.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/hal_nordic.csv
@@ -1,0 +1,6 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,anangl,maintain
+user,hubertmis,push
+user,nordic-krch,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/hal_nuvoton.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/hal_nuvoton.csv
@@ -1,0 +1,4 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,ssekar15,maintain

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/hal_nxp.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/hal_nxp.csv
@@ -1,0 +1,9 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,dleach02,maintain
+user,mmahadevan108,maintain
+user,decsny,push
+user,manuargue,push
+user,PetervdPerk-NXP,push
+user,bperseghetti,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/hal_openisa.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/hal_openisa.csv
@@ -1,0 +1,4 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,dleach02,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/hal_quicklogic.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/hal_quicklogic.csv
@@ -1,0 +1,4 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,fkokosinski,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/hal_renesas.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/hal_renesas.csv
@@ -1,0 +1,11 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,KhiemNguyenT,maintain
+user,ioannis-karachalios,maintain
+user,blauret,push
+user,andrzej-kaczmarek,push
+user,ydamigos,push
+user,soburi,push
+user,duynguyenxa,push
+user,thaoluonguw,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/hal_rpi_pico.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/hal_rpi_pico.csv
@@ -1,0 +1,7 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,soburi,maintain
+user,yonsch,push
+user,threeeights,push
+user,ajf58,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/hal_silabs.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/hal_silabs.csv
@@ -1,0 +1,11 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,jhedberg,maintain
+user,asmellby,maintain
+user,jerome-pouiller,push
+user,sateeshkotapati,push
+user,yonsch,push
+user,mnkp,push
+user,rettichschnidi,push
+user,Martinhoff-maker,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/hal_st.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/hal_st.csv
@@ -1,0 +1,5 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,avisconti,maintain
+user,erwango,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/hal_stm32.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/hal_stm32.csv
@@ -1,0 +1,10 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,erwango,maintain
+user,FRASTM,push
+user,gautierg-st,push
+user,marwaiehm-st,push
+user,asm5878,push
+user,HoZHel,push
+user,benothmn-st,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/hal_tdk.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/hal_tdk.csv
@@ -1,0 +1,7 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,afontaine-invn,maintain
+user,rbuisson-invn,push
+user,gjabouley-invn,push
+user,sriccardi-invn,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/hal_telink.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/hal_telink.csv
@@ -1,0 +1,4 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,andy-liu-telink,maintain

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/hal_ti.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/hal_ti.csv
@@ -1,0 +1,4 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,vaishnavachath,maintain

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/hal_wch.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/hal_wch.csv
@@ -1,0 +1,6 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,nzmichaelh,maintain
+user,kholia,maintain
+user,VynDragon,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/hal_wurthelektronik.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/hal_wurthelektronik.csv
@@ -1,0 +1,4 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,mah-eiSmart,maintain

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/hal_xtensa.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/hal_xtensa.csv
@@ -1,0 +1,6 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,dcpleung,maintain
+user,andyross,push
+user,nashif,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/hostap.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/hostap.csv
@@ -1,0 +1,6 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,krish2718,maintain
+user,jukkar,maintain
+user,MaochenWang1,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/liblc3.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/liblc3.csv
@@ -1,0 +1,7 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,Casper-Bonde-Bose,maintain
+user,MariuszSkamra,maintain
+user,thalley,push
+user,asbjornsabo,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/libmctp.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/libmctp.csv
@@ -1,0 +1,6 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,teburd,maintain
+user,nashif,push
+user,inteljiangwe1,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/libmetal.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/libmetal.csv
@@ -1,0 +1,5 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,carlocaione,push
+user,arnopo,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/littlefs.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/littlefs.csv
@@ -1,0 +1,3 @@
+type,id,permission
+team,maintainers,triage
+team,release,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/loramac-node.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/loramac-node.csv
@@ -1,0 +1,4 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,Mani-Sadhasivam,maintain

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/lvgl.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/lvgl.csv
@@ -1,0 +1,7 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,faxe1008,maintain
+user,brgl,push
+user,pdgendt,push
+user,uLipe,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/lz4.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/lz4.csv
@@ -1,0 +1,4 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,parthitce,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/mbedtls.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/mbedtls.csv
@@ -1,0 +1,9 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,d3zd3z,maintain
+user,ceolin,maintain
+user,wearyzen,push
+user,valeriosetti,push
+user,tomi-font,push
+user,ithinuel,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/mcuboot.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/mcuboot.csv
@@ -1,0 +1,6 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,d3zd3z,maintain
+user,de-nordic,push
+user,nordicjm,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/mipi-sys-t.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/mipi-sys-t.csv
@@ -1,0 +1,4 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,dcpleung,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/nanopb.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/nanopb.csv
@@ -1,0 +1,4 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,pdgendt,maintain

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/net-tools.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/net-tools.csv
@@ -1,0 +1,5 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,jukkar,maintain
+user,rlubos,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/nrf_hw_models.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/nrf_hw_models.csv
@@ -1,0 +1,6 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,aescolar,maintain
+user,wopu-ot,push
+user,thoh-ot,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/nrf_wifi.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/nrf_wifi.csv
@@ -1,0 +1,8 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,krish2718,maintain
+user,sachinthegreen,maintain
+user,udaynordic,push
+user,rajb9,push
+user,srkanordic,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/open-amp.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/open-amp.csv
@@ -1,0 +1,6 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,carlocaione,push
+user,uLipe,push
+user,iuliana-prodan,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/openthread.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/openthread.csv
@@ -1,0 +1,9 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,rlubos,maintain
+user,pdgendt,push
+user,canisLupus1313,push
+user,mariuszpos,push
+user,edmont,push
+user,maciejbaczmanski,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/percepio.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/percepio.csv
@@ -1,0 +1,5 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,eriktamlin,maintain
+user,aronlander-pe,maintain

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/picolibc.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/picolibc.csv
@@ -1,0 +1,5 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,keith-packard,maintain
+user,stephanosio,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/psa-arch-tests.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/psa-arch-tests.csv
@@ -1,0 +1,7 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,d3zd3z,maintain
+user,Vge0rge,push
+user,wearyzen,push
+user,ithinuel,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/segger.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/segger.csv
@@ -1,0 +1,4 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,nordic-krch,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/sof.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/sof.csv
@@ -1,0 +1,8 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,kv2019i,maintain
+user,andyross,push
+user,nashif,push
+user,lyakh,push
+user,lgirdwood,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/tf-m-tests.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/tf-m-tests.csv
@@ -1,0 +1,7 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,d3zd3z,maintain
+user,Vge0rge,push
+user,wearyzen,push
+user,ithinuel,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/tflite-micro.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/tflite-micro.csv
@@ -1,0 +1,5 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,XenuIsWatching,maintain
+user,laurenmurphyx64,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/thrift.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/thrift.csv
@@ -1,0 +1,4 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,cfriedt,maintain

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/tinycrypt.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/tinycrypt.csv
@@ -1,0 +1,3 @@
+type,id,permission
+team,maintainers,triage
+team,release,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/trusted-firmware-a.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/trusted-firmware-a.csv
@@ -1,0 +1,8 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,povergoing,maintain
+user,sgrrzhf,maintain
+user,carlocaione,push
+user,wearyzen,push
+user,ithinuel,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/trusted-firmware-m.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/trusted-firmware-m.csv
@@ -1,0 +1,9 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,d3zd3z,maintain
+user,Vge0rge,push
+user,wearyzen,push
+user,valeriosetti,push
+user,tomi-font,push
+user,ithinuel,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/uoscore-uedhoc.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/uoscore-uedhoc.csv
@@ -1,0 +1,5 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,rlubos,maintain
+user,StefanHri,maintain

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/zcbor.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/zcbor.csv
@@ -1,0 +1,4 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,de-nordic,maintain

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/zephyr-lang-rust.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/zephyr-lang-rust.csv
@@ -1,0 +1,4 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,d3zd3z,maintain

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/zscilib.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/zscilib.csv
@@ -1,0 +1,4 @@
+type,id,permission
+team,maintainers,triage
+team,release,push
+user,microbuilder,maintain


### PR DESCRIPTION
This commit adds a script that generates the member/collaborator list
for the "west project" (aka. module) repositories.

---

Part of https://github.com/zephyrproject-rtos/infrastructure/issues/111