### PR TITLE
sync_module_repo_members: Add global admins with admin permission level

### DIFF
--- a/terraform/github-zephyrproject-rtos/repository/repository-members/cmsis-dsp.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/cmsis-dsp.csv
@@ -2,4 +2,4 @@ type,id,permission
 team,maintainers,triage
 team,release,push
 user,XenuIsWatching,maintain
-user,stephanosio,push
+user,stephanosio,admin

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/cmsis-nn.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/cmsis-nn.csv
@@ -2,4 +2,4 @@ type,id,permission
 team,maintainers,triage
 team,release,push
 user,XenuIsWatching,maintain
-user,stephanosio,push
+user,stephanosio,admin

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/cmsis.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/cmsis.csv
@@ -1,6 +1,6 @@
 type,id,permission
 team,maintainers,triage
 team,release,push
-user,stephanosio,maintain
+user,stephanosio,admin
 user,microbuilder,push
 user,povergoing,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/hal_cypress.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/hal_cypress.csv
@@ -2,6 +2,6 @@ type,id,permission
 team,maintainers,triage
 team,release,push
 user,ifyall,maintain
-user,nashif,push
+user,nashif,admin
 user,sreeramIfx,push
 user,mcatee-infineon,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/hal_xtensa.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/hal_xtensa.csv
@@ -3,4 +3,4 @@ team,maintainers,triage
 team,release,push
 user,dcpleung,maintain
 user,andyross,push
-user,nashif,push
+user,nashif,admin

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/libmctp.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/libmctp.csv
@@ -2,5 +2,5 @@ type,id,permission
 team,maintainers,triage
 team,release,push
 user,teburd,maintain
-user,nashif,push
+user,nashif,admin
 user,inteljiangwe1,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/picolibc.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/picolibc.csv
@@ -2,4 +2,4 @@ type,id,permission
 team,maintainers,triage
 team,release,push
 user,keith-packard,maintain
-user,stephanosio,push
+user,stephanosio,admin

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/sof.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/sof.csv
@@ -3,6 +3,6 @@ team,maintainers,triage
 team,release,push
 user,kv2019i,maintain
 user,andyross,push
-user,nashif,push
+user,nashif,admin
 user,lyakh,push
 user,lgirdwood,push

--- a/terraform/github-zephyrproject-rtos/scripts/sync_module_repo_members.sh
+++ b/terraform/github-zephyrproject-rtos/scripts/sync_module_repo_members.sh
@@ -43,6 +43,11 @@ echo "${maintainers_data}" | yq &> /dev/null || (
   exit 10
 )
 
+# Read global admin list
+global_admins=$(<${manifest_path}/global-admins.csv)
+global_admins=$(echo "${global_admins}" | tail -n +2)
+global_admins=(${global_admins})
+
 # Get the maintainer data for modules (aka. west projects)
 readarray module_maintainer_entries < <(echo "${maintainers_data}" |
   yq -r -o=j -I=0 'with_entries(select(.key == "West project: *")) | to_entries()[]')
@@ -70,11 +75,19 @@ for module_maintainer_entry in "${module_maintainer_entries[@]}"; do
 
   ## Write maintainer entries
   for maintainer in ${maintainers}; do
-    echo "user,${maintainer},maintain" >> ${collab_list_file}
+    if [[ " ${global_admins[@]} " =~ " ${maintainer} " ]]; then
+      echo "user,${maintainer},admin" >> ${collab_list_file}
+    else
+      echo "user,${maintainer},maintain" >> ${collab_list_file}
+    fi
   done
 
   ## Write collaborator entries
   for collaborator in ${collaborators}; do
-    echo "user,${collaborator},push" >> ${collab_list_file}
+    if [[ " ${global_admins[@]} " =~ " ${collaborator} " ]]; then
+      echo "user,${collaborator},admin" >> ${collab_list_file}
+    else
+      echo "user,${collaborator},push" >> ${collab_list_file}
+    fi
   done
 done


### PR DESCRIPTION
GitHub API returns the effective/resultant permission for repository
collaborators and this is always `admin` for the global
admin/organisation owner users.

This commit updates the module repository member sync script such that
the global admin users are added with `admin` permission level to module
repositories.