### PR TITLE
sync_module_repo_members: Skip BabbleSim modules

### DIFF
--- a/terraform/github-zephyrproject-rtos/repository/repository-members/babblesim_base.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/babblesim_base.csv
@@ -1,4 +1,0 @@
-type,id,permission
-team,maintainers,triage
-team,release,push
-user,aescolar,maintain

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/babblesim_ext_2G4_channel_NtNcable.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/babblesim_ext_2G4_channel_NtNcable.csv
@@ -1,4 +1,0 @@
-type,id,permission
-team,maintainers,triage
-team,release,push
-user,aescolar,maintain

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/babblesim_ext_2G4_channel_multiatt.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/babblesim_ext_2G4_channel_multiatt.csv
@@ -1,4 +1,0 @@
-type,id,permission
-team,maintainers,triage
-team,release,push
-user,aescolar,maintain

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/babblesim_ext_2G4_device_WLAN_actmod.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/babblesim_ext_2G4_device_WLAN_actmod.csv
@@ -1,4 +1,0 @@
-type,id,permission
-team,maintainers,triage
-team,release,push
-user,aescolar,maintain

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/babblesim_ext_2G4_device_burst_interferer.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/babblesim_ext_2G4_device_burst_interferer.csv
@@ -1,4 +1,0 @@
-type,id,permission
-team,maintainers,triage
-team,release,push
-user,aescolar,maintain

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/babblesim_ext_2G4_device_playback.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/babblesim_ext_2G4_device_playback.csv
@@ -1,4 +1,0 @@
-type,id,permission
-team,maintainers,triage
-team,release,push
-user,aescolar,maintain

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/babblesim_ext_2G4_libPhyComv1.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/babblesim_ext_2G4_libPhyComv1.csv
@@ -1,4 +1,0 @@
-type,id,permission
-team,maintainers,triage
-team,release,push
-user,aescolar,maintain

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/babblesim_ext_2G4_modem_BLE_simple.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/babblesim_ext_2G4_modem_BLE_simple.csv
@@ -1,4 +1,0 @@
-type,id,permission
-team,maintainers,triage
-team,release,push
-user,aescolar,maintain

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/babblesim_ext_2G4_modem_magic.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/babblesim_ext_2G4_modem_magic.csv
@@ -1,4 +1,0 @@
-type,id,permission
-team,maintainers,triage
-team,release,push
-user,aescolar,maintain

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/babblesim_ext_2G4_phy_v1.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/babblesim_ext_2G4_phy_v1.csv
@@ -1,4 +1,0 @@
-type,id,permission
-team,maintainers,triage
-team,release,push
-user,aescolar,maintain

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/babblesim_ext_libCryptov1.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/babblesim_ext_libCryptov1.csv
@@ -1,4 +1,0 @@
-type,id,permission
-team,maintainers,triage
-team,release,push
-user,aescolar,maintain

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/bsim.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/bsim.csv
@@ -1,4 +1,0 @@
-type,id,permission
-team,maintainers,triage
-team,release,push
-user,aescolar,maintain

--- a/terraform/github-zephyrproject-rtos/scripts/sync_module_repo_members.sh
+++ b/terraform/github-zephyrproject-rtos/scripts/sync_module_repo_members.sh
@@ -48,6 +48,22 @@ global_admins=$(<${manifest_path}/global-admins.csv)
 global_admins=$(echo "${global_admins}" | tail -n +2)
 global_admins=(${global_admins})
 
+# Set skipped module list
+skipped_modules=(
+  bsim
+  babblesim_base
+  babblesim_ext_2G4_libPhyComv1
+  babblesim_ext_2G4_phy_v1
+  babblesim_ext_2G4_channel_NtNcable
+  babblesim_ext_2G4_channel_multiatt
+  babblesim_ext_2G4_modem_magic
+  babblesim_ext_2G4_modem_BLE_simple
+  babblesim_ext_2G4_device_burst_interferer
+  babblesim_ext_2G4_device_WLAN_actmod
+  babblesim_ext_2G4_device_playback
+  babblesim_ext_libCryptov1
+  )
+
 # Get the maintainer data for modules (aka. west projects)
 readarray module_maintainer_entries < <(echo "${maintainers_data}" |
   yq -r -o=j -I=0 'with_entries(select(.key == "West project: *")) | to_entries()[]')
@@ -61,9 +77,14 @@ for module_maintainer_entry in "${module_maintainer_entries[@]}"; do
   collaborators=$(echo "${module_maintainer_entry}" |
     jq -r 'try .value.collaborators[]')
 
-  echo "Processing ${name}"
+  # Check for skipped module
+  if [[ " ${skipped_modules[@]} " =~ " ${name} " ]]; then
+    echo "Skipped ${name}"
+    continue
+  fi
 
   # Write repositoy member list
+  echo "Processing ${name}"
   collab_list_file="${manifest_path}/repository/repository-members/${name}.csv"
 
   ## Write CSV header


### PR DESCRIPTION
Skip generating member list for BabbleSim module repositories because
they are not hosted by zephyrproject-rtos organisation.