### PR TITLE
github-zephyrproject-rtos: Use canonical GitHub usernames

### DIFF
--- a/terraform/github-zephyrproject-rtos/repository/repository-members/hal_rpi_pico.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/hal_rpi_pico.csv
@@ -3,5 +3,5 @@ team,maintainers,triage
 team,release,push
 user,soburi,maintain
 user,yonsch,push
-user,threeeights,push
+user,ThreeEights,push
 user,ajf58,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/liblc3.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/liblc3.csv
@@ -3,5 +3,5 @@ team,maintainers,triage
 team,release,push
 user,Casper-Bonde-Bose,maintain
 user,MariuszSkamra,maintain
-user,thalley,push
+user,Thalley,push
 user,asbjornsabo,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/trusted-firmware-a.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/trusted-firmware-a.csv
@@ -2,7 +2,7 @@ type,id,permission
 team,maintainers,triage
 team,release,push
 user,povergoing,maintain
-user,sgrrzhf,maintain
+user,SgrrZhf,maintain
 user,carlocaione,push
 user,wearyzen,push
 user,ithinuel,push

--- a/terraform/github-zephyrproject-rtos/scripts/get_canonical_username.sh
+++ b/terraform/github-zephyrproject-rtos/scripts/get_canonical_username.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# This script queries and print out the "canonical" username for a GitHub user.
+#
+# As example, for a user with the registered username `RandomUser1234`, this
+# scripts returns `RandomUser1234` when `randomuser1234`, `rAndOMuSer1234` or
+# any other case variation of the username is specified.
+
+set -e
+
+usage()
+{
+	echo "Usage: $(basename $0) username"
+}
+
+# Validate and parse arguments
+if [ "$1" == "" ]; then
+  usage
+  echo
+  echo "username must be specified."
+  exit 1
+fi
+
+username=$1
+cache_file=".username.cache"
+
+# Attempt to retrieve the canonical username from a local cache file
+if [ -f "${cache_file}" ]; then
+  cache_data=($(<${cache_file}))
+
+  for cache_entry in "${cache_data[@]}"; do
+    if [[ "${cache_entry,,}" == "${username,,}" ]]; then
+      # Found a matching cache entry; print it and exit
+      echo "${cache_entry}"
+      exit 0
+    fi
+  done
+fi
+
+# Retrieve user data from GitHub
+user_data=$(gh api /users/${username})
+canonical_username=$(echo "${user_data}" | jq -r '.login')
+
+# Ensure that canonical username is alphanumerically identical to the specified
+# username
+if [[ "${canonical_username,,}" != "${username,,}" ]]; then
+  echo "Invalid user data."
+  exit 2
+fi
+
+# Save canonical username to the cache file
+echo "${canonical_username}" >> ${cache_file}
+
+# Print canonical username
+echo "${canonical_username}"

--- a/terraform/github-zephyrproject-rtos/scripts/sync_module_repo_members.sh
+++ b/terraform/github-zephyrproject-rtos/scripts/sync_module_repo_members.sh
@@ -5,6 +5,8 @@
 
 set -e
 
+get_canonical_username="$(dirname "${BASH_SOURCE[0]}")/get_canonical_username.sh"
+
 usage()
 {
   echo "Usage $(basename $0) maintainers_file manifest_path"
@@ -96,19 +98,23 @@ for module_maintainer_entry in "${module_maintainer_entries[@]}"; do
 
   ## Write maintainer entries
   for maintainer in ${maintainers}; do
-    if [[ " ${global_admins[@]} " =~ " ${maintainer} " ]]; then
-      echo "user,${maintainer},admin" >> ${collab_list_file}
+    username=$(${get_canonical_username} ${maintainer})
+
+    if [[ " ${global_admins[@]} " =~ " ${username} " ]]; then
+      echo "user,${username},admin" >> ${collab_list_file}
     else
-      echo "user,${maintainer},maintain" >> ${collab_list_file}
+      echo "user,${username},maintain" >> ${collab_list_file}
     fi
   done
 
   ## Write collaborator entries
   for collaborator in ${collaborators}; do
-    if [[ " ${global_admins[@]} " =~ " ${collaborator} " ]]; then
-      echo "user,${collaborator},admin" >> ${collab_list_file}
+    username=$(${get_canonical_username} ${collaborator})
+
+    if [[ " ${global_admins[@]} " =~ " ${username} " ]]; then
+      echo "user,${username},admin" >> ${collab_list_file}
     else
-      echo "user,${collaborator},push" >> ${collab_list_file}
+      echo "user,${username},push" >> ${collab_list_file}
     fi
   done
 done

--- a/terraform/github-zephyrproject-rtos/scripts/sync_team_membership.sh
+++ b/terraform/github-zephyrproject-rtos/scripts/sync_team_membership.sh
@@ -5,6 +5,8 @@
 
 set -e
 
+get_canonical_username="$(dirname "${BASH_SOURCE[0]}")/get_canonical_username.sh"
+
 usage()
 {
 	echo "Usage: $(basename $0) maintainers_file manifest_path"
@@ -62,11 +64,13 @@ write_team_member_list()
   member_list="$2"
 
   echo "username,role" > "${output_file}"
-  for user in ${member_list}; do
-    if [[ " ${global_admins[@]} " =~ " ${user} " ]]; then
-      echo "${user},maintainer" >> ${output_file}
+  for username in ${member_list}; do
+    canonical_username=$(${get_canonical_username} ${username})
+
+    if [[ " ${global_admins[@]} " =~ " ${canonical_username} " ]]; then
+      echo "${canonical_username},maintainer" >> ${output_file}
     else
-      echo "${user},member" >> "${output_file}"
+      echo "${canonical_username},member" >> "${output_file}"
     fi
   done
 }

--- a/terraform/github-zephyrproject-rtos/team/team-members/collaborators.csv
+++ b/terraform/github-zephyrproject-rtos/team/team-members/collaborators.csv
@@ -14,6 +14,7 @@ alevkoy,member
 alexanderwachter,member
 alvsun,member
 alxelax,member
+anangl,member
 Andrewpini,member
 andrzej-kaczmarek,member
 andyross,member
@@ -23,7 +24,6 @@ asbjornsabo,member
 asemjonovs,member
 asm5878,member
 asmellby,member
-attie-argentum,member
 avisconti,member
 avolmat-st,member
 axelnxp,member
@@ -43,7 +43,6 @@ canisLupus1313,member
 carlescufi,maintainer
 carlocaione,member
 casparfriedrich,member
-Casper-Bonde-Bose,member
 ceolin,member
 cfriedt,member
 clamattia,member
@@ -53,6 +52,7 @@ cvinayak,member
 danieldegrasse,member
 Dat-NguyenDuy,member
 dbaluta,member
+DBS06,member
 dcpleung,member
 de-nordic,member
 decsny,member
@@ -157,16 +157,17 @@ MaochenWang1,member
 marcinszkudlinski,member
 marekmatej,member
 mariuszpos,member
-MariuszSkamra,member
 MarkWangChinese,member
 Martinhoff-maker,member
 martinjaeger,member
 marwaiehm-st,member
+masz-nordic,member
 mateusz-holenko,member
 mathieuchopstm,member
 MaureenHelm,member
 maxd-nordic,member
 mbolivar,member
+mcatee-infineon,member
 mgielda,member
 michalsimek,member
 microbuilder,member
@@ -185,7 +186,6 @@ niym-ot,member
 nordic-auko,member
 nordic-krch,member
 nordicjm,member
-npal-cy,member
 npitre,member
 omkar3141,member
 ozersa,member
@@ -223,6 +223,7 @@ sjanc,member
 sjg20,member
 soburi,member
 softwarecki,member
+sreeramIfx,member
 sriccardi-invn,member
 srkanordic,member
 ssekar15,member
@@ -242,7 +243,6 @@ Thalley,member
 thaoluonguw,member
 thedjnK,member
 thenguyenyf,member
-theob-pro,member
 thoh-ot,member
 threeeights,member
 tmleman,member

--- a/terraform/github-zephyrproject-rtos/team/team-members/collaborators.csv
+++ b/terraform/github-zephyrproject-rtos/team/team-members/collaborators.csv
@@ -27,7 +27,7 @@ asmellby,member
 avisconti,member
 avolmat-st,member
 axelnxp,member
-ayush1325,member
+Ayush1325,member
 babrsn,member
 bbolen,member
 BeckmaR,member
@@ -101,7 +101,7 @@ inteljiangwe1,member
 ithinuel,member
 iuliana-prodan,member
 jackrosenthal,member
-jarmouniA,member
+JarmouniA,member
 jaz1-nordic,member
 jbehrensnx,member
 jeppenodgaard,member
@@ -121,14 +121,14 @@ jxstelter,member
 KamilxPaszkiet,member
 kartben,member
 katsuster,member
-kehintel,member
+KeHIntel,member
 keith-packard,member
 keith-zephyr,member
 kevinwang821020,member
 kgugala,member
 kkasperczyk-no,member
 kl-cruz,member
-kludentwo,member
+Kludentwo,member
 krish2718,member
 kv2019i,member
 KyraLengfeld,member
@@ -216,9 +216,9 @@ sachinthegreen,member
 sateeshkotapati,member
 seov-nordic,member
 SeppoTakalo,member
-sgrrzhf,member
+SgrrZhf,member
 simhein,member
-sir-branch,member
+Sir-Branch,member
 sjanc,member
 sjg20,member
 soburi,member
@@ -244,7 +244,7 @@ thaoluonguw,member
 thedjnK,member
 thenguyenyf,member
 thoh-ot,member
-threeeights,member
+ThreeEights,member
 tmleman,member
 tmon-nordic,member
 TomChang19,member

--- a/terraform/github-zephyrproject-rtos/team/team-members/maintainers.csv
+++ b/terraform/github-zephyrproject-rtos/team/team-members/maintainers.csv
@@ -1,4 +1,5 @@
 username,role
+3rang,member
 aaillet,member
 aaronemassey,member
 abrodkin,member
@@ -32,6 +33,7 @@ cvinayak,member
 cyliangtw,member
 d3zd3z,member
 danieldegrasse,member
+Dat-NguyenDuy,member
 dbaluta,member
 dcpleung,member
 de-nordic,member
@@ -56,6 +58,7 @@ GTLin08,member
 henrikbrixandersen,member
 ifyall,member
 ioannis-karachalios,member
+iuliana-prodan,member
 jadonk,member
 jakub-uC,member
 JasonLin-RealTek,member

--- a/terraform/github-zephyrproject-rtos/team/team-members/maintainers.csv
+++ b/terraform/github-zephyrproject-rtos/team/team-members/maintainers.csv
@@ -131,7 +131,7 @@ ruuddw,member
 sachinthegreen,member
 sambhurst,member
 seov-nordic,member
-sgrrzhf,member
+SgrrZhf,member
 sidcha,member
 simonguinot,member
 sjanc,member


### PR DESCRIPTION
Updates all GitHub usernames with the "canonical" form
because Terraform handles the GitHub usernames in a case sensitive
manner.