### PR TITLE
.gitignore: Add *.cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+# Ignore cache files
+*.cache


### PR DESCRIPTION
Ignore `*.cache` files created by the scripts under `terraform/github-zephyrproject-rtos`.