### PR TITLE
github: Remove dipakgmx from tsc

### DIFF
--- a/terraform/github-zephyrproject-rtos/team/team-members/tsc.csv
+++ b/terraform/github-zephyrproject-rtos/team/team-members/tsc.csv
@@ -4,7 +4,6 @@ carlescufi,maintainer
 ceolin,member
 d3zd3z,member
 daor-oti,member
-dipakgmx,member
 dleach02,member
 erwango,member
 henrikbrixandersen,member


### PR DESCRIPTION
Remove the user 'dipakgmx' from the 'tsc' team since he is no longer working at Zeiss.