### PR TITLE
sync_module_repo_members: Exclude edtt and nrf_hw_models

### DIFF
--- a/terraform/github-zephyrproject-rtos/repository/repository-members/edtt.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/edtt.csv
@@ -1,6 +1,6 @@
 type,id,permission
 team,maintainers,triage
 team,release,push
-user,aescolar,maintain
+user,aescolar,admin
 user,wopu-ot,push
 user,thoh-ot,push

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/nrf_hw_models.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/nrf_hw_models.csv
@@ -1,6 +1,6 @@
 type,id,permission
 team,maintainers,triage
 team,release,push
-user,aescolar,maintain
+user,aescolar,admin
 user,wopu-ot,push
 user,thoh-ot,push

--- a/terraform/github-zephyrproject-rtos/scripts/sync_module_repo_members.sh
+++ b/terraform/github-zephyrproject-rtos/scripts/sync_module_repo_members.sh
@@ -52,6 +52,7 @@ global_admins=(${global_admins})
 
 # Set skipped module list
 skipped_modules=(
+  # BSIM repositories are hosted outside the zephyrproject-rtos organisation
   bsim
   babblesim_base
   babblesim_ext_2G4_libPhyComv1
@@ -64,6 +65,10 @@ skipped_modules=(
   babblesim_ext_2G4_device_WLAN_actmod
   babblesim_ext_2G4_device_playback
   babblesim_ext_libCryptov1
+  # edtt and nrf_hw_models require special handling due to how module
+  # synchronisation is done
+  edtt
+  nrf_hw_models
   )
 
 # Get the maintainer data for modules (aka. west projects)


### PR DESCRIPTION
The `edtt` and `nrf_hw_models` repositories currently require special
handling because the module maintainer, @aescolar, requires `admin`
(i.e. not `maintain`) for upstream synchronisation.