### PR TITLE
github: Add @sorru94 to contributors

### DIFF
--- a/terraform/github-zephyrproject-rtos/team/team-members/contributors.csv
+++ b/terraform/github-zephyrproject-rtos/team/team-members/contributors.csv
@@ -534,6 +534,7 @@ smrtos,member
 snematbakhsh,member
 soburi,member
 softwarecki,member
+sorru94,member
 spoorthik,member
 sreeramIfx,member
 sriccardi-invn,member


### PR DESCRIPTION
Add @sorru94 to the 'contributors' team as per the contributor nomination zephyrproject-rtos/zephyr#93883.

Closes https://github.com/zephyrproject-rtos/zephyr/issues/93883