### PR TITLE
terraform: Migrate to AWS Secrets Manager

### DIFF
--- a/terraform/aws-zephyr-alpha/main.tf
+++ b/terraform/aws-zephyr-alpha/main.tf
@@ -13,9 +13,17 @@ provider "helm" {
   }
 }
 
-# HashiCorp Vault Secrets zephyr-secrets Vault
-data "hcp_vault_secrets_app" "zephyr_secrets" {
-  app_name = "zephyr-secrets"
+provider "aws" {
+  region = "us-east-1"
+}
+
+# AWS Secrets Manager terraform-zephyr-secrets Secret
+data "aws_secretsmanager_secret_version" "terraform-zephyr-secrets" {
+  secret_id = "terraform-zephyr-secrets"
+}
+
+locals {
+  zephyr_secrets = jsondecode(data.aws_secretsmanager_secret_version.terraform-zephyr-secrets.secret_string)
 }
 
 # Zephyr AWS Blueprints
@@ -44,5 +52,5 @@ module "zephyr_aws_blueprints" {
 
   github_organization = "zephyrproject-rtos"
 
-  kube_prometheus_stack_grafana_password = data.hcp_vault_secrets_app.zephyr_secrets.secrets["kube_prometheus_stack_grafana_password"]
+  kube_prometheus_stack_grafana_password = local.zephyr_secrets.kube_prometheus_stack_grafana_password
 }

--- a/terraform/cnx-zephyr-ci/.terraform.lock.hcl
+++ b/terraform/cnx-zephyr-ci/.terraform.lock.hcl
@@ -18,6 +18,28 @@ provider "registry.terraform.io/gavinbunney/kubectl" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "6.11.0"
+  hashes = [
+    "h1:Ao401IE4NzgRUKOKpAus0Ul47QgDNCbFIyXRHUEI4A8=",
+    "zh:02da12526aa5abdb26c41f204c159ee0ef26a735534e09024e00870cda45a058",
+    "zh:1a9205ee7a09b152e402df6c5a4479bef4f518ec39d097922556dd47157ff62f",
+    "zh:43cb5143f0c6cc2b34923b0dc8db60d25452336bd6bceafc3f2d9812c72ed1b9",
+    "zh:44d6581a1fc0b4f07569600bf6bee3b0bf5281fc82e6494bd72197f6335aa3e1",
+    "zh:4ece6fab65bdb237917227e9c4336dec1300a88e85f84e19a198be93304d7c9b",
+    "zh:76e2209d31d8b2e4759f57998503ad2b6181f0fe3df6b7082999f330137b3ffa",
+    "zh:8300f016f799d3540bf5f5faf3d8d3e829acc82dd77a5882d7399e66942c6fea",
+    "zh:8c2f1bb8e52aa70964423b2e20648b043c1ad40726f7ebde915f71b7e07dd84a",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a77ea5655019566c8727403c54beb962cc7510ff9cf663d6e8d600800e872cb7",
+    "zh:af0b1c6cd78d9b4670f77ee169abd0bf6e293077f231540f3ae94cd7f8d90369",
+    "zh:b7c4a50fdcb1c977ea09ac880b91bc65e49b4448837610f25ee2567777d98ca9",
+    "zh:bbc578faeeb15ed8c0853d382f73260cc95a8bcf14a5455a0ed4ca61c243970c",
+    "zh:cb3892c781b3f928b0c42261ae8c03cef8ac0cbbdddf0ab0637eea9f49482f80",
+    "zh:e562cd17bb3fb318b5ba7a006c461fd2a6703c8f9862a7a6494cf304922f4da0",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/hcp" {
   version     = "0.82.0"
   constraints = "~> 0.82.0"

--- a/terraform/cnx-zephyr-ci/main.tf
+++ b/terraform/cnx-zephyr-ci/main.tf
@@ -30,9 +30,17 @@ provider "helm" {
   }
 }
 
-# HashiCorp Vault Secrets zephyr-secrets Vault
-data "hcp_vault_secrets_app" "zephyr_secrets" {
-  app_name = "zephyr-secrets"
+provider "aws" {
+  region = "us-east-1"
+}
+
+# AWS Secrets Manager terraform-zephyr-secrets Secret
+data "aws_secretsmanager_secret_version" "terraform-zephyr-secrets" {
+  secret_id = "terraform-zephyr-secrets"
+}
+
+locals {
+  zephyr_secrets = jsondecode(data.aws_secretsmanager_secret_version.terraform-zephyr-secrets.secret_string)
 }
 
 # kubernetes-1.23-zephyr-ci Magnum Kubernetes Cluster Template
@@ -349,9 +357,9 @@ resource "kubernetes_secret" "arc_github_app" {
     namespace = "arc-runners"
   }
   data = {
-    github_app_id = data.hcp_vault_secrets_app.zephyr_secrets.secrets["zephyr_runner_github_app_id"]
-    github_app_installation_id = data.hcp_vault_secrets_app.zephyr_secrets.secrets["zephyr_runner_github_app_installation_id"]
-    github_app_private_key = data.hcp_vault_secrets_app.zephyr_secrets.secrets["zephyr_runner_github_app_private_key"]
+    github_app_id = local.zephyr_secrets.zephyr_runner_github_app_id
+    github_app_installation_id = local.zephyr_secrets.zephyr_runner_github_app_installation_id
+    github_app_private_key = local.zephyr_secrets.zephyr_runner_github_app_private_key
   }
   depends_on = [kubernetes_namespace.arc_runners]
 }

--- a/terraform/cnx-zephyr-ci/versions.tf
+++ b/terraform/cnx-zephyr-ci/versions.tf
@@ -22,5 +22,9 @@ terraform {
       source  = "hashicorp/helm"
       version = ">= 2.4.1"
     }
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.40"
+    }
   }
 }

--- a/terraform/cnx-zephyr-test/.terraform.lock.hcl
+++ b/terraform/cnx-zephyr-test/.terraform.lock.hcl
@@ -18,6 +18,29 @@ provider "registry.terraform.io/gavinbunney/kubectl" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.11.0"
+  constraints = ">= 5.40.0"
+  hashes = [
+    "h1:Ao401IE4NzgRUKOKpAus0Ul47QgDNCbFIyXRHUEI4A8=",
+    "zh:02da12526aa5abdb26c41f204c159ee0ef26a735534e09024e00870cda45a058",
+    "zh:1a9205ee7a09b152e402df6c5a4479bef4f518ec39d097922556dd47157ff62f",
+    "zh:43cb5143f0c6cc2b34923b0dc8db60d25452336bd6bceafc3f2d9812c72ed1b9",
+    "zh:44d6581a1fc0b4f07569600bf6bee3b0bf5281fc82e6494bd72197f6335aa3e1",
+    "zh:4ece6fab65bdb237917227e9c4336dec1300a88e85f84e19a198be93304d7c9b",
+    "zh:76e2209d31d8b2e4759f57998503ad2b6181f0fe3df6b7082999f330137b3ffa",
+    "zh:8300f016f799d3540bf5f5faf3d8d3e829acc82dd77a5882d7399e66942c6fea",
+    "zh:8c2f1bb8e52aa70964423b2e20648b043c1ad40726f7ebde915f71b7e07dd84a",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a77ea5655019566c8727403c54beb962cc7510ff9cf663d6e8d600800e872cb7",
+    "zh:af0b1c6cd78d9b4670f77ee169abd0bf6e293077f231540f3ae94cd7f8d90369",
+    "zh:b7c4a50fdcb1c977ea09ac880b91bc65e49b4448837610f25ee2567777d98ca9",
+    "zh:bbc578faeeb15ed8c0853d382f73260cc95a8bcf14a5455a0ed4ca61c243970c",
+    "zh:cb3892c781b3f928b0c42261ae8c03cef8ac0cbbdddf0ab0637eea9f49482f80",
+    "zh:e562cd17bb3fb318b5ba7a006c461fd2a6703c8f9862a7a6494cf304922f4da0",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/hcp" {
   version     = "0.82.0"
   constraints = "~> 0.82.0"

--- a/terraform/cnx-zephyr-test/main.tf
+++ b/terraform/cnx-zephyr-test/main.tf
@@ -30,9 +30,17 @@ provider "helm" {
   }
 }
 
-# HashiCorp Vault Secrets zephyr-secrets Vault
-data "hcp_vault_secrets_app" "zephyr_secrets" {
-  app_name = "zephyr-secrets"
+provider "aws" {
+  region = "us-east-1"
+}
+
+# AWS Secrets Manager terraform-zephyr-secrets Secret
+data "aws_secretsmanager_secret_version" "terraform-zephyr-secrets" {
+  secret_id = "terraform-zephyr-secrets"
+}
+
+locals {
+  zephyr_secrets = jsondecode(data.aws_secretsmanager_secret_version.terraform-zephyr-secrets.secret_string)
 }
 
 # kubernetes-1.23-zephyr-test1 Magnum Kubernetes Cluster Template
@@ -176,9 +184,9 @@ resource "kubernetes_secret" "arc_github_app" {
     namespace = "arc-runners"
   }
   data = {
-    github_app_id = data.hcp_vault_secrets_app.zephyr_secrets.secrets["test_runner_github_app_id"]
-    github_app_installation_id = data.hcp_vault_secrets_app.zephyr_secrets.secrets["test_runner_github_app_installation_id"]
-    github_app_private_key = data.hcp_vault_secrets_app.zephyr_secrets.secrets["test_runner_github_app_private_key"]
+    github_app_id = data.hcp_local.zephyr_secrets.test_runner_github_app_id
+    github_app_installation_id = local.zephyr_secrets.test_runner_github_app_installation_id
+    github_app_private_key = local.zephyr_secrets.test_runner_github_app_private_key
   }
   depends_on = [kubernetes_namespace.arc_runners]
 }

--- a/terraform/cnx-zephyr-test/versions.tf
+++ b/terraform/cnx-zephyr-test/versions.tf
@@ -22,5 +22,9 @@ terraform {
       source  = "hashicorp/helm"
       version = ">= 2.4.1"
     }
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.40"
+    }
   }
 }

--- a/terraform/hzr-ci-main/.terraform.lock.hcl
+++ b/terraform/hzr-ci-main/.terraform.lock.hcl
@@ -24,6 +24,29 @@ provider "registry.terraform.io/gavinbunney/kubectl" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.11.0"
+  constraints = ">= 5.40.0"
+  hashes = [
+    "h1:Ao401IE4NzgRUKOKpAus0Ul47QgDNCbFIyXRHUEI4A8=",
+    "zh:02da12526aa5abdb26c41f204c159ee0ef26a735534e09024e00870cda45a058",
+    "zh:1a9205ee7a09b152e402df6c5a4479bef4f518ec39d097922556dd47157ff62f",
+    "zh:43cb5143f0c6cc2b34923b0dc8db60d25452336bd6bceafc3f2d9812c72ed1b9",
+    "zh:44d6581a1fc0b4f07569600bf6bee3b0bf5281fc82e6494bd72197f6335aa3e1",
+    "zh:4ece6fab65bdb237917227e9c4336dec1300a88e85f84e19a198be93304d7c9b",
+    "zh:76e2209d31d8b2e4759f57998503ad2b6181f0fe3df6b7082999f330137b3ffa",
+    "zh:8300f016f799d3540bf5f5faf3d8d3e829acc82dd77a5882d7399e66942c6fea",
+    "zh:8c2f1bb8e52aa70964423b2e20648b043c1ad40726f7ebde915f71b7e07dd84a",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a77ea5655019566c8727403c54beb962cc7510ff9cf663d6e8d600800e872cb7",
+    "zh:af0b1c6cd78d9b4670f77ee169abd0bf6e293077f231540f3ae94cd7f8d90369",
+    "zh:b7c4a50fdcb1c977ea09ac880b91bc65e49b4448837610f25ee2567777d98ca9",
+    "zh:bbc578faeeb15ed8c0853d382f73260cc95a8bcf14a5455a0ed4ca61c243970c",
+    "zh:cb3892c781b3f928b0c42261ae8c03cef8ac0cbbdddf0ab0637eea9f49482f80",
+    "zh:e562cd17bb3fb318b5ba7a006c461fd2a6703c8f9862a7a6494cf304922f4da0",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/hcp" {
   version     = "0.82.0"
   constraints = "~> 0.82.0"

--- a/terraform/hzr-ci-main/versions.tf
+++ b/terraform/hzr-ci-main/versions.tf
@@ -18,5 +18,9 @@ terraform {
       source  = "hashicorp/helm"
       version = ">= 2.4.1"
     }
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.40"
+    }
   }
 }


### PR DESCRIPTION
HCP Vault Secrets is now completely dead (no longer works and causes Terraform runs to fail), so migrate to the AWS Secrets Manager for providing the secrets required by the Terraform manifests.

The secrets previously stored in the HCP Vault Secrets have already been added to the AWS Secrets Manager `terraform-zephyr-secrets` secret.

Closes https://github.com/zephyrproject-rtos/infrastructure/issues/265