### PR TITLE
remove anasnashif, was used as a test account

### DIFF
--- a/terraform/github-zephyrproject-rtos/team/team-members/contributors.csv
+++ b/terraform/github-zephyrproject-rtos/team/team-members/contributors.csv
@@ -39,7 +39,6 @@ alxelax,member
 AmberHibberd,member
 amergnat,member
 anangl,member
-anasnashif,member
 anchao,member
 andre-stefanov,member
 Andrewpini,member


### PR DESCRIPTION
remove anasnashif

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
