### PR TITLE
github: Remove contributor 'clamattia'

### DIFF
--- a/terraform/github-zephyrproject-rtos/team/team-members/contributors.csv
+++ b/terraform/github-zephyrproject-rtos/team/team-members/contributors.csv
@@ -112,7 +112,6 @@ chrisc11,member
 chrta,member
 chunlinhan,member
 ClaCodes,member
-clamattia,member
 codecoup-tester,member
 con-pax,member
 congnguyenhuu,member


### PR DESCRIPTION
The GitHub account 'clamattia' no longer exists and has been replaced by 'ClaCodes' [1].

[1] https://github.com/zephyrproject-rtos/zephyr/commit/5b68835fca3ef2f9bb1db9d25f1ec2327b174432