### PR TITLE
github: Remove GAnthony from contributors

### DIFF
--- a/terraform/github-zephyrproject-rtos/team/team-members/contributors.csv
+++ b/terraform/github-zephyrproject-rtos/team/team-members/contributors.csv
@@ -188,7 +188,6 @@ fundakol,member
 fvincenzo,member
 galak,member
 gamnes,member
-GAnthony,member
 gautierg-st,member
 gbarkadiusz,member
 gbernatxintel,member


### PR DESCRIPTION
Remove GAnthony from the `contributors` team because this user repeatedly failed to accept the invitation and is now somehow causing API errors when running Terraform apply.