### PR TITLE
github: Remove tims-ot from contributors

### DIFF
--- a/terraform/github-zephyrproject-rtos/team/team-members/contributors.csv
+++ b/terraform/github-zephyrproject-rtos/team/team-members/contributors.csv
@@ -581,7 +581,6 @@ ThreeEights,member
 thst-nordic,member
 tiennguyenzg,member
 timork,member
-tims-ot,member
 tleksell-pe,member
 tmalhotr,member
 tmleman,member


### PR DESCRIPTION
Remove `tims-ot` from the contributors team because this user no longer exists.