### PR TITLE
github: Remove Sizurka from contributors

### DIFF
--- a/terraform/github-zephyrproject-rtos/team/team-members/contributors.csv
+++ b/terraform/github-zephyrproject-rtos/team/team-members/contributors.csv
@@ -525,7 +525,6 @@ simtind,member
 singalsu,member
 Sir-Branch,member
 SiyuanCheng-CN,member
-Sizurka,member
 sjanc,member
 sjg20,member
 smalae,member


### PR DESCRIPTION
Remove `Sizurka` from the contributors team because this user seems to have blocked the zephyrproject-rtos organisation (getting "403 Blocked" when attempting to invite).