### PR TITLE
kconfiglib: adding tejlmand as maintainer for kconfiglib

### DIFF
--- a/terraform/github-zephyrproject-rtos/team/team-members/kconfiglib.csv
+++ b/terraform/github-zephyrproject-rtos/team/team-members/kconfiglib.csv
@@ -1,5 +1,5 @@
 username,role
+tejlmand,maintainer
 carlescufi,maintainer
-jackrosenthal,member
 nashif,maintainer
 stephanosio,maintainer


### PR DESCRIPTION
Adding tejlmand as maintainer for kconfiglib.
Removing jackrosental.