### PR TITLE
github: Remove contributor 'LixinGuoX'

### DIFF
--- a/terraform/github-zephyrproject-rtos/team/team-members/contributors.csv
+++ b/terraform/github-zephyrproject-rtos/team/team-members/contributors.csv
@@ -337,7 +337,6 @@ lgl88911,member
 Liam-Ogletree,member
 likongintel,member
 LingaoM,member
-LixinGuoX,member
 lixuzha,member
 ljd42,member
 lmajewski,member


### PR DESCRIPTION
'LixinGuoX' is no longer a valid GitHub user.