### PR TITLE
github: add action-zephyr-setup, pr-dashboard and zephyr-merge-list

### DIFF
--- a/terraform/github-zephyrproject-rtos/repository/repository-members/action-zephyr-setup.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/action-zephyr-setup.csv
@@ -1,0 +1,4 @@
+type,id,permission
+team,release,push
+user,fabiobaltieri,admin
+user,kartben,admin

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/pr-dashboard.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/pr-dashboard.csv
@@ -1,0 +1,4 @@
+type,id,permission
+team,release,push
+user,fabiobaltieri,admin
+user,kartben,admin

--- a/terraform/github-zephyrproject-rtos/repository/repository-members/zephyr-merge-list.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/zephyr-merge-list.csv
@@ -1,0 +1,4 @@
+type,id,permission
+team,release,push
+user,fabiobaltieri,admin
+user,kartben,admin


### PR DESCRIPTION
Add a user list for the action-zephyr-setup, pr-dashboard and zephyr-merge-list repositories, just setting release team as triage and Ben and I as admin.