### PR TITLE
github: Remove 'seko-nordic' from contributors

### DIFF
--- a/terraform/github-zephyrproject-rtos/team/team-members/contributors.csv
+++ b/terraform/github-zephyrproject-rtos/team/team-members/contributors.csv
@@ -536,7 +536,6 @@ scottwcpg,member
 SdtElectronics,member
 seankyer,member
 SebastianBoe,member
-seko-nordic,member
 seov-nordic,member
 SeppoTakalo,member
 serhiy-katsyuba-intel,member


### PR DESCRIPTION
Remove the user 'seko-nordic' from the contributors team because the attempt to invite this user by Terraform persistently failed (likely because the user declined the invitation).