### PR TITLE
github: Fix GitHub username mcxuted -> mcuxted

### DIFF
--- a/terraform/github-zephyrproject-rtos/team/team-members/contributors.csv
+++ b/terraform/github-zephyrproject-rtos/team/team-members/contributors.csv
@@ -409,7 +409,7 @@ mbolivar,member
 mbukowsk,member
 mcatee-infineon,member
 mchp-asif,member
-mcxuted,member
+mcuxted,member
 mdubielx,member
 MeganHansen,member
 meijemac,member


### PR DESCRIPTION
The correct username for `mcxuted` is `mcuxted` [1].

[1] https://github.com/zephyrproject-rtos/zephyr/issues/102936