### PR TITLE
Add VynDragon and BOJIT as hal_wch maintainers

### DIFF
--- a/terraform/github-zephyrproject-rtos/repository/repository-members/hal_wch.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/hal_wch.csv
@@ -3,4 +3,5 @@ team,maintainers,triage
 team,release,push
 user,nzmichaelh,maintain
 user,kholia,maintain
-user,VynDragon,push
+user,VynDragon,maintain
+user,BOJIT,maintain


### PR DESCRIPTION
Adds two additional maintainers to avoid PRs stalling.

Apologies if I'm not meant to open PRs under this repo. Feel free to close.

Currently some changes to `hal_wch` are stalling as one of the existing maintainers isn't very active on the project.
https://github.com/zephyrproject-rtos/hal_wch

Recently I have taken over maintaining the Zephyr WCH code, but the permissions for `hal_wch` don't seem to have updated.
https://github.com/zephyrproject-rtos/zephyr/blob/main/MAINTAINERS.yml#L6209

This PR adds both myself and @VynDragon as maintainers so we can review incoming PRs on `hal_wch`.

I believe that these files might normally be updated via a script. If so, please feel free to close this if the script is re-run.