### PR TITLE
add jhol as contributor

### DIFF
--- a/terraform/github-zephyrproject-rtos/team/team-members/contributors.csv
+++ b/terraform/github-zephyrproject-rtos/team/team-members/contributors.csv
@@ -278,6 +278,7 @@ jgediya,member
 jgoppert,member
 JhanBoChao-Realtek,member
 jhedberg,member
+jhol,member
 jhqian,member
 JiafeiPan,member
 jilaypandya,member


### PR DESCRIPTION
maintainer of openrisc port.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
