### PR TITLE
zephyr-runner-v2: hzr: Increase linux-x64-4xlarge max limit to 108

### DIFF
--- a/kubernetes/zephyr-runner-v2/hzr/zephyr-runner-scale-sets/zephyr-runner-v2-linux-x64-4xlarge-hzr/values.yaml
+++ b/kubernetes/zephyr-runner-v2/hzr/zephyr-runner-scale-sets/zephyr-runner-v2-linux-x64-4xlarge-hzr/values.yaml
@@ -5,7 +5,7 @@ runnerScaleSetName: "zrv2-linux-x64-4xlarge-hzr"
 runnerGroup: "zephyr-runner-v2-linux-x64-4xlarge"
 
 # maxRunners is the max number of runners the autoscaling runner set will scale up to.
-maxRunners: 100
+maxRunners: 108
 
 # minRunners is the min number of runners the autoscaling runner set will scale down to.
 minRunners: 0


### PR DESCRIPTION
```
Increase the Hetzner hosted `zephyr-runner-v2-linux-x64-4xlarge` runner
maximum scaling limit from 100 to 108 to take advantage of all threads
available in the Hetzner cluster compute nodes:

    18 nodes
  * 96 threads/nodes
  / 16 threads/runner
  = 108 runners

Note that this leaves very little processing margin on the compute nodes
when the CI jobs are maxing out the CPU and may slow down kubelet
operations; if this happens and turns out to be a significant problem,
this change should be reverted.
```