### PR TITLE
cloud-monitor: Fix failed ephemeral runner clean-up step

### DIFF
--- a/.github/workflows/cloud-monitor.yml
+++ b/.github/workflows/cloud-monitor.yml
@@ -197,7 +197,7 @@ jobs:
 
           echo "$runnerList" |
             jq -r '.items[].status | select(.phase == "Failed").runnerName' |
-            xargs kubectl delete ephemeralrunner
+            xargs kubectl -n arc-runners delete ephemeralrunner
 
           .github/log.sh INFO "cnx: kube1: Cleaned up ${failedCount} ephemeral runners with failed status."
         fi
@@ -318,7 +318,7 @@ jobs:
 
           echo "$runnerList" |
             jq -r '.items[].status | select(.phase == "Failed").runnerName' |
-            xargs kubectl delete ephemeralrunner
+            xargs kubectl -n arc-runners delete ephemeralrunner
 
           .github/log.sh INFO "hzr: ci-main: Cleaned up ${failedCount} ephemeral runners with failed status."
         fi


### PR DESCRIPTION
Ensure that the failed ephemeral runner deletion command runs in the context of the `arc-runners` namespace.