### PR TITLE
add teburd to the release team

### DIFF
--- a/terraform/github-zephyrproject-rtos/team/team-members/release.csv
+++ b/terraform/github-zephyrproject-rtos/team/team-members/release.csv
@@ -12,3 +12,4 @@ MaureenHelm,maintainer
 mmahadevan108,member
 nashif,maintainer
 stephanosio,maintainer
+teburd,member


### PR DESCRIPTION
Tom is now a release manager for 4.5.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
