### PR TITLE
github: Sync with MAINTAINERS.yml

### DIFF
--- a/terraform/github-zephyrproject-rtos/team/team-members/collaborators.csv
+++ b/terraform/github-zephyrproject-rtos/team/team-members/collaborators.csv
@@ -253,6 +253,7 @@ masz-nordic,member
 mateusz-holenko,member
 mathieuchopstm,member
 matt-rodgers,member
+Mattemagikern,member
 MaureenHelm,member
 maxd-nordic,member
 maxdog988,member
@@ -260,6 +261,7 @@ mbolivar,member
 mcatee-infineon,member
 mchp-asif,member
 mcuxted,member
+merin-infineon,member
 mgielda,member
 michalsimek,member
 microbuilder,member
@@ -359,6 +361,7 @@ stephanosio,maintainer
 str4t0m,member
 sudhir-alifsemi,member
 sunil-abraham,member
+SusanRemm,member
 swift-tk,member
 swinslow,member
 sylvioalves,member

--- a/terraform/github-zephyrproject-rtos/team/team-members/maintainers.csv
+++ b/terraform/github-zephyrproject-rtos/team/team-members/maintainers.csv
@@ -71,6 +71,7 @@ glneo,member
 gmarull,member
 grahamroff-dev,member
 GTLin08,member
+hakehuang,member
 hakonfam,member
 HalfSweet,member
 henrikbrixandersen,member
@@ -139,6 +140,7 @@ nzmichaelh,member
 parphane,member
 PavelVPV,member
 pdgendt,member
+PerMac,member
 peter-mitsis,member
 PetervdPerk-NXP,member
 pideu-sj,member
@@ -204,6 +206,7 @@ ydamigos,member
 yonsch,member
 yperess,member
 YuzhuoLiuRTK,member
+yvesll,member
 zejiang0jason,member
 ZhaoxiangJin,member
 ZhiyuanTang17,member


### PR DESCRIPTION
Sync team and repository members with
MAINTAINERS.yml@cab619ee9f2e4013b1aa97609c6c3d61ab6dc5c2.

@stephanosio this is a large change "line removal" wise but AFAICT it is correct - not sure why some maintainers or collaborators were still in the file when to the best of my knowledge they should be gone (long gone for some of them).