### PR TITLE
github: Remove 'merin-infineon' user

### DIFF
--- a/terraform/github-zephyrproject-rtos/repository/repository-members/hal_infineon.csv
+++ b/terraform/github-zephyrproject-rtos/repository/repository-members/hal_infineon.csv
@@ -10,5 +10,4 @@ user,billwatersiii,push
 user,jsbatch,push
 user,Peterson-Brett,push
 user,lauracarlesso,push
-user,merin-infineon,push
 user,ifx-rmcs,push

--- a/terraform/github-zephyrproject-rtos/team/team-members/collaborators.csv
+++ b/terraform/github-zephyrproject-rtos/team/team-members/collaborators.csv
@@ -276,7 +276,6 @@ mcatee-infineon,member
 mchp-asif,member
 mcuxted,member
 meijemac,member
-merin-infineon,member
 mgielda,member
 michalsimek,member
 microbuilder,member

--- a/terraform/github-zephyrproject-rtos/team/team-members/contributors.csv
+++ b/terraform/github-zephyrproject-rtos/team/team-members/contributors.csv
@@ -431,7 +431,6 @@ mdubielx,member
 MeganHansen,member
 meijemac,member
 mengxianglinx,member
-merin-infineon,member
 mgielda,member
 michael1schmidt,member
 michaeljones,member


### PR DESCRIPTION
The GitHub user 'merin-infineon' no longer exists.